### PR TITLE
Add SECURITY.md, clarify wb = white-box, fix stale counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Red-Team AI
+# wb-red-team
 
-White-box red-teaming framework for agentic AI apps. It analyzes your app's source code to discover tools, roles, and guardrails, then generates LLM-powered attacks across 60 categories and adapts over multiple rounds to find vulnerabilities.
+White-box red-teaming framework for agentic AI apps. Analyze source code, generate LLM-powered attacks across 85+ categories, and adapt over multiple rounds to find vulnerabilities.
 
 ## Attack Categories
 
@@ -212,7 +212,7 @@ Edit `config.json` to point at your AI app:
 | `attackConfig.judgeModel`          | No       | Model for response judging (defaults to `llmModel`)                                   |
 | `attackConfig.enableLlmGeneration` | No       | Use LLM to generate novel attacks (default: true)                                     |
 | `attackConfig.maxMultiTurnSteps`   | No       | Max steps per multi-turn attack (default: 8)                                          |
-| `attackConfig.enabledCategories`   | No       | Allowlist of attack category IDs to run. Omit or set to `[]` to run all 60 categories |
+| `attackConfig.enabledCategories`   | No       | Allowlist of attack category IDs to run. Omit or set to `[]` to run all categories |
 
 ### LLM Provider Examples
 
@@ -244,7 +244,7 @@ Edit `config.json` to point at your AI app:
 
 ### Selecting Attack Categories
 
-By default all 60 categories run. Use `enabledCategories` to focus on a subset:
+By default all categories run. Use `enabledCategories` to focus on a subset:
 
 ```json
 "attackConfig": {
@@ -289,7 +289,7 @@ Set to `[]` or omit the field entirely to run all categories.
 
 ## Demo Target App
 
-Use [demo-agentic-app](https://github.com/sundi133/demo-agentic-app) as a reference target to try the framework against. It's a fully functional agentic AI app with tools (file read, email, Slack, database queries, GitHub gists), role-based access, JWT auth, and intentional vulnerabilities — ideal for testing all 60 attack categories.
+Use [demo-agentic-app](https://github.com/sundi133/demo-agentic-app) as a reference target to try the framework against. It's a fully functional agentic AI app with tools (file read, email, Slack, database queries, GitHub gists), role-based access, JWT auth, and intentional vulnerabilities — ideal for testing all attack categories.
 
 ```bash
 # 1. Clone and start the demo app
@@ -496,7 +496,7 @@ Use the dropdown at the top to switch between historical reports.
 
 ### Dashboard Overview
 
-The main view gives you an at-a-glance breakdown of a full red-team run security score, total attacks fired, vulnerabilities discovered, and how many defenses held. The category breakdown table shows coverage across all 46+ attack categories, and the top attack strategies panel highlights which techniques were most effective so you know where to focus hardening efforts.
+The main view gives you an at-a-glance breakdown of a full red-team run security score, total attacks fired, vulnerabilities discovered, and how many defenses held. The category breakdown table shows coverage across all attack categories, and the top attack strategies panel highlights which techniques were most effective so you know where to focus hardening efforts.
 
 ![Dashboard Overview](assets/dashboard-overview.png)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 1.x     | Yes       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in wb-red-team, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, email **security@votal.ai** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+We will acknowledge receipt within 48 hours and aim to provide a fix or mitigation within 7 days for critical issues.
+
+## Scope
+
+This project is a security testing tool designed to find vulnerabilities in AI agent applications. The attack payloads and techniques contained in this repository are intentional and for authorized testing purposes only.
+
+**In scope:**
+- Vulnerabilities in the framework itself (config parsing, report generation, dashboard, auth handling)
+- Dependency vulnerabilities
+- Information disclosure in generated reports
+
+**Out of scope:**
+- Attack payloads and seed attacks (these are intentionally adversarial by design)
+- Vulnerabilities in the demo target app (it is intentionally vulnerable for testing)
+
+## Responsible Use
+
+This tool is intended for authorized security testing of AI applications you own or have permission to test. Unauthorized use against third-party systems is prohibited.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wb-red-team",
   "version": "1.0.0",
-  "description": "White-box red-teaming framework for agentic AI apps — analyzes source code, generates LLM-powered attacks across 60 categories, and produces scored security reports",
+  "description": "White-box red-teaming framework for agentic AI apps — analyzes source code, generates LLM-powered attacks across 85+ categories, and produces scored security reports",
   "type": "module",
   "license": "MIT",
   "author": "Jyotirmoy Sundi",
@@ -15,6 +15,7 @@
   },
   "keywords": [
     "red-team",
+    "white-box",
     "security",
     "testing",
     "llm",
@@ -28,7 +29,7 @@
     "node": ">=18.0.0"
   },
   "bin": {
-    "red-team-ai": "./red-team.ts"
+    "wb-red-team": "./red-team.ts"
   },
   "scripts": {
     "start": "tsx red-team.ts",


### PR DESCRIPTION
## Summary

Addresses feedback from [Linux Foundation Insights](https://insights.linuxfoundation.org/project/wb-red-team) where the project shows **Health Score: Unsteady** and **"No description available"**.

- **Add `SECURITY.md`** — Linux Foundation checks for a security policy file. Includes responsible disclosure process, scope definition, and responsible use notice.
- **Clarify "wb" in README title** — Rename from "Red-Team AI" to "wb-red-team" so the project name is consistent and "white-box" is immediately clear (feedback: "wb is unclear").
- **Fix stale category counts** — README and package.json said "60 categories" but there are now 85 attack modules. Updated to "85+" and removed hardcoded counts where possible to prevent future drift.
- **Fix bin name** — `package.json` bin still referenced `red-team-ai`, updated to `wb-red-team`.
- **Add `white-box` keyword** to package.json for discoverability.

## What this improves

| Linux Foundation Check | Before | After |
|---|---|---|
| Security policy (SECURITY.md) | Missing | Present |
| Project naming clarity | "wb is unclear" | Title explains white-box |
| Metadata accuracy | "60 categories" (stale) | "85+" (current) |

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — all 79 tests pass
- [x] No functional code changes — metadata and docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)