### PR TITLE
Dashboard UI enhancements: strategy filter, button styling, and null-safety fix

### DIFF
--- a/attacks/path-traversal.ts
+++ b/attacks/path-traversal.ts
@@ -83,9 +83,9 @@ ${JSON.stringify(
   analysis.tools
     .filter(
       (t) =>
-        t.name.includes("file") ||
-        t.name.includes("read") ||
-        t.name.includes("repo"),
+        t.name?.includes("file") ||
+        t.name?.includes("read") ||
+        t.name?.includes("repo"),
     )
     .map((t) => ({ name: t.name, description: t.description })),
   null,

--- a/attacks/sql-injection.ts
+++ b/attacks/sql-injection.ts
@@ -46,7 +46,7 @@ export const sqlInjectionModule: AttackModule = {
     return `You are a red-team attacker testing for SQL injection via AI agent database tools.
 
 AVAILABLE TOOLS:
-\${JSON.stringify(analysis.tools.filter((t) => t.name.includes("db") || t.name.includes("query") || t.name.includes("sql")).map((t) => ({ name: t.name, description: t.description })), null, 2)}
+\${JSON.stringify(analysis.tools.filter((t) => t.name?.includes("db") || t.name?.includes("query") || t.name?.includes("sql")).map((t) => ({ name: t.name, description: t.description })), null, 2)}
 
 SENSITIVE DATA:
 \${JSON.stringify(analysis.sensitiveData, null, 2)}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -592,12 +592,12 @@
         display: flex;
         gap: 8px;
         margin-bottom: 12px;
-        flex-wrap: wrap;
         align-items: center;
       }
       .filter-bar label {
         font-size: 12px;
         color: var(--text2);
+        white-space: nowrap;
       }
       .filter-bar select,
       .filter-bar input {
@@ -607,9 +607,10 @@
         border-radius: 4px;
         padding: 4px 8px;
         font-size: 12px;
+        max-width: 140px;
       }
       .filter-bar input {
-        width: 200px;
+        width: 130px;
       }
 
       /* Detail grid for findings */
@@ -655,18 +656,18 @@
         padding: 32px;
       }
       .owasp-btn {
-        background: linear-gradient(135deg, var(--accent), var(--purple));
+        background: var(--surface2);
         color: #fff;
-        border: none;
+        border: 1px solid var(--border);
         border-radius: 8px;
         padding: 12px 28px;
         font-size: 14px;
         font-weight: 600;
         cursor: pointer;
-        transition: opacity 0.2s;
+        transition: background 0.2s;
       }
       .owasp-btn:hover {
-        opacity: 0.85;
+        background: var(--surface);
       }
       .owasp-btn:disabled {
         opacity: 0.5;
@@ -1346,6 +1347,8 @@
           .sort()
           .map((c) => `<option value="${c}">${fmtCat(c)}</option>`)
           .join("")}</select>
+        <label>Strategy:</label>
+        <select id="filterStrategy"><option value="">All</option></select>
         <label>Search:</label>
         <input id="filterSearch" placeholder="Filter results...">
       </div>
@@ -1372,6 +1375,7 @@
 
         renderCategories();
         renderStrategies();
+        populateStrategyDropdown();
         renderFindings();
         renderRoundTabs();
         renderRoundDetail();
@@ -1381,7 +1385,29 @@
         $("#filterVerdict").addEventListener("change", renderFindings);
         $("#filterSev").addEventListener("change", renderFindings);
         $("#filterCat").addEventListener("change", renderFindings);
+        $("#filterStrategy").addEventListener("change", renderFindings);
         $("#filterSearch").addEventListener("input", renderFindings);
+      }
+
+      function populateStrategyDropdown() {
+        const sel = $("#filterStrategy");
+        if (!sel || !report) return;
+        sel.innerHTML = '<option value="">All</option>';
+        const strategies = [
+          ...new Set(
+            report.rounds.flatMap((round) =>
+              round.results
+                .map((r) => r.attack.strategyName)
+                .filter(Boolean),
+            ),
+          ),
+        ].sort();
+        strategies.forEach((s) => {
+          const opt = document.createElement("option");
+          opt.value = s;
+          opt.textContent = s.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
+          sel.appendChild(opt);
+        });
       }
 
       function fmtCat(c) {
@@ -1831,12 +1857,14 @@
         const verdict = $("#filterVerdict")?.value || "";
         const sev = $("#filterSev")?.value || "";
         const cat = $("#filterCat")?.value || "";
+        const strategy = $("#filterStrategy")?.value || "";
         const search = ($("#filterSearch")?.value || "").toLowerCase();
 
         let findings = buildResultRows();
         if (verdict) findings = findings.filter((f) => f.verdict === verdict);
         if (sev) findings = findings.filter((f) => f.severity === sev);
         if (cat) findings = findings.filter((f) => f.category === cat);
+        if (strategy) findings = findings.filter((f) => f.strategyName === strategy);
         if (search)
           findings = findings.filter(
             (f) =>


### PR DESCRIPTION
## Summary

Three dashboard UI enhancements and a crash fix for attack modules when scanning non-standard codebases (e.g., Python backends).

### Changes

1. **Strategy Dropdown Filter** — Adds a "Strategy" dropdown to the Results filter bar, between Category and Search. Dynamically populated from each report's attack results. Empty when no strategies were configured for that run.
<img width="935" height="108" alt="image" src="https://github.com/user-attachments/assets/2b1c8173-8867-4352-9e2c-512d161092a2" />

2. **OWASP Button Restyling** — Changed the "Run OWASP Mapping Analysis" button from a bright blue/purple gradient to a dark surface color (`--surface2`) with a subtle border, matching the dashboard's dark theme.
<img width="991" height="195" alt="image" src="https://github.com/user-attachments/assets/20cf0ec3-477e-4ae5-a518-cbfa49dd32c9" />

3. **Filter Bar Layout Fix** — Removed `flex-wrap: wrap` so all filters stay on one line. Added `max-width: 140px` to all selects and reduced the search input to `130px` for consistent sizing.

4. **Null-Safety Fix (Bug)** — Fixed `TypeError: Cannot read properties of undefined (reading 'includes')` crash in `attacks/path-traversal.ts` and `attacks/sql-injection.ts`. When scanning codebases with tools that have undefined `name` fields (e.g., Python backends parsed via `**/*.py` glob), `t.name.includes()` would crash the entire attack run during Round 1 planning. Fixed with optional chaining (`t.name?.includes()`).

### Files Changed

| File | Change |
|------|--------|
| `dashboard/index.html` | Strategy dropdown, button restyle, filter bar CSS |
| `attacks/path-traversal.ts` | `t.name.includes()` → `t.name?.includes()` |
| `attacks/sql-injection.ts` | `t.name.includes()` → `t.name?.includes()` |

## How It Was Tested

### 1. Strategy Dropdown Filter

**Setup:** Ran attacks against ZeroClaw (`wss://zeroclaw-production-5575.up.railway.app/ws/chat`) with `config.zeroclaw.json` containing 35 enabled strategies.

**Steps:**
1. Run `npm run dashboard` → opens `http://localhost:4200`
2. Select the report from **4/8/2026 05:25 PM** (181 attacks, 35 strategies configured)
3. Verify the Strategy dropdown shows strategies like "Academic Computation Disguise", "Algorithm Analysis", etc.
4. Select a strategy (e.g., "Base64 Context Hint") → results table filters to only attacks using that strategy
5. Combine with other filters (Verdict: PASS, Category: Prompt Injection, Strategy: Base64 Context Hint) → all filters work together
6. Switch to the report from **4/8/2026 02:38 PM** (156 attacks, NO strategies configured)
7. Verify the Strategy dropdown is empty — only shows "All" with no options

**Result:** Dropdown correctly reflects what was used per report. Empty when no strategies existed.

### 2. OWASP Button Restyling

**Steps:**
1. Open any report in the dashboard
2. Scroll to the "OWASP Compliance Mapping" section
3. Verify the "Run OWASP Mapping Analysis" button uses the dark surface color with a subtle border
4. Hover over the button → verify it transitions to a slightly lighter surface color
5. Verify white text remains readable on the dark background

**Result:** Button matches the dark dashboard theme. Text is white and clearly readable.

### 3. Filter Bar Layout

**Steps:**
1. Open any report with results
2. Verify all 5 filter elements (Verdict, Severity, Category, Strategy, Search) are on a single line
3. Verify the Strategy dropdown is the same width as the Category dropdown
4. Resize the browser window → verify filters don't wrap to a second line at reasonable widths

**Result:** All filters fit on one line with consistent sizing.

### 4. Null-Safety Fix (Bug Reproduction & Fix)

**Reproduction:**
1. Set `codebaseGlob` to `"**/*.{ts,py,js,yaml,yml,json}"` in config (to scan Python files)
2. Point `codebasePath` to ZeroClaw's codebase
3. Run `npx tsx red-team.ts config.zeroclaw.json`
4. **Before fix:** Crash at Round 1 planning with:
   ```
   Fatal error: TypeError: Cannot read properties of undefined (reading 'includes')
       at <anonymous> (attacks/path-traversal.ts:86:16)
   ```
5. **After fix:** Attack planning completes successfully, 402 attacks executed across 2 rounds

**Result:** Full attack run completed with 402 attacks, 240 PASS, 73 FAIL, 89 PARTIAL, 0 errors.

### Streaming / WebSocket Testing

These changes don't modify WebSocket transport. WebSocket streaming was tested as part of the attack runs above — all 402 attacks were delivered via WebSocket (`wss://zeroclaw-production-5575.up.railway.app/ws/chat` with `zeroclaw.v1` subprotocol). Response times ranged from 2s to 58s, confirming streaming works reliably under sustained load over multi-hour runs (~3.5 hours for the full 402-attack run).

## Test plan

- [x] Strategy dropdown populates from report data when strategies exist
- [x] Strategy dropdown is empty when no strategies were configured
- [x] Strategy filter works in combination with Verdict, Severity, Category, Search
- [x] OWASP button uses dark theme styling with visible border
- [x] All filter bar elements fit on one line
- [x] Attack runs no longer crash on codebases with undefined tool names
- [x] WebSocket attack delivery works end-to-end
