### PR TITLE
fix: resolve CI type-check errors in response-analyzer and discovery-round

### DIFF
--- a/lib/discovery-round.ts
+++ b/lib/discovery-round.ts
@@ -284,6 +284,7 @@ const DISCOVERY_PROBES: { category: string; probes: string[] }[] = [
 
 function buildDiscoveryAttack(probe: string): Attack {
   return {
+    id: `discovery-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     name: `Discovery: ${probe.slice(0, 60)}...`,
     category: "sensitive_data",
     description: "Automated discovery probe",
@@ -292,6 +293,7 @@ function buildDiscoveryAttack(probe: string): Attack {
     authMethod: "none",
     role: "user",
     payload: { message: probe },
+    isLlmGenerated: false,
   };
 }
 

--- a/lib/response-analyzer.ts
+++ b/lib/response-analyzer.ts
@@ -487,7 +487,7 @@ ${responseBody.slice(0, 10000)}`;
 
   return {
     verdict,
-    reasoning: result.reasoning ?? "",
+    reasoning: typeof result.reasoning === "string" ? result.reasoning : "",
     confidence,
     evidenceFor:
       typeof result.evidence_for === "string" ? result.evidence_for : undefined,


### PR DESCRIPTION
## Summary

Fixes two TypeScript strict-mode errors introduced in PRs #55 and #56 that caused the CI type-check step to fail across all three Node.js versions (18, 20, 22). The errors were caught by `tsc --noEmit` in the CI pipeline.

### Changes

1. **Type-safe reasoning extraction** (`lib/response-analyzer.ts#L490`) — `result` is typed as `Record<string, unknown>`, so `result.reasoning` is `unknown`. The original code used `result.reasoning ?? ""` which resolves to `unknown | string` — TypeScript cannot assign this to `string`. Fixed with explicit `typeof` narrowing: `typeof result.reasoning === "string" ? result.reasoning : ""`.

2. **Missing required Attack fields** (`lib/discovery-round.ts#L286`) — The `Attack` interface requires `id: string` and `isLlmGenerated: boolean`, but `buildDiscoveryAttack()` was returning an object without these two properties. Fixed by adding:
   - `id`: unique identifier using `discovery-${Date.now()}-${randomSuffix}`
   - `isLlmGenerated: false` since discovery probes are hardcoded, not LLM-generated

### Files Changed

| File | Change |
|------|--------|
| `lib/response-analyzer.ts` | L490: `result.reasoning ?? ""` → `typeof result.reasoning === "string" ? result.reasoning : ""` |
| `lib/discovery-round.ts` | L286: Added `id` and `isLlmGenerated: false` to `buildDiscoveryAttack()` return object |

## How It Was Tested

### 1. Local Type Check

**Steps:**
1. Run `npx tsc --noEmit` before fix → 2 errors:
   ```
   lib/response-analyzer.ts(490,5): error TS2322: Type '{}' is not assignable to type 'string'.
   lib/discovery-round.ts(286,3): error TS2741: Type '{ name: string; category: "sensitive_data"; ... }'
     is missing the following properties from type 'Attack': id, isLlmGenerated
   ```
2. Apply fixes
3. Run `npx tsc --noEmit` after fix → **0 errors**

**Result:** Clean type check with zero errors.

### 2. CI Failure Reproduction

**Before fix — CI Actions run [#85](https://github.com/sundi133/wb-red-team/actions/runs/24457469734):**
- check (18): failed — both errors
- check (20): failed — both errors
- check (22): failed — both errors

**After fix — expected:**
- All three Node.js version checks should pass

### 3. Runtime Verification

These are type-only fixes with no behavioral change:
- `typeof result.reasoning === "string" ? result.reasoning : ""` produces the same result as `result.reasoning ?? ""` at runtime — both return the string value or empty string
- Adding `id` and `isLlmGenerated` to discovery attacks only adds metadata fields that were already expected downstream

## Test plan

- [x] `npx tsc --noEmit` passes with 0 errors locally
- [x] `response-analyzer.ts` reasoning extraction returns correct string values
- [x] `discovery-round.ts` builds valid Attack objects with id and isLlmGenerated
- [ ] CI pipeline passes on all three Node.js versions (18, 20, 22) after merge
