### PR TITLE
Add timeouts to target and LLM HTTP requests (fixes #29)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -94,6 +94,8 @@
     "maxAnalysisBatches": 3,
     "customAttacksOnly": false,
     "appTailoredCustomPromptCount": 0,
+    "targetTimeoutMs": 30000,
+    "llmTimeoutMs": 60000,
     "enabledStrategies": [
       "life_or_death_emergency",
       "critical_deadline_pressure",

--- a/lib/attack-runner.ts
+++ b/lib/attack-runner.ts
@@ -37,6 +37,7 @@ async function loginForToken(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email: cred.email, password: cred.password }),
+    signal: AbortSignal.timeout(config.attackConfig.targetTimeoutMs!),
   });
   if (!res.ok) throw new Error(`Login failed: ${res.status}`);
   const data = (await res.json()) as { token?: string };
@@ -275,6 +276,7 @@ export async function executeAttack(
       method,
       headers: finalHeaders,
       body: requestBody,
+      signal: AbortSignal.timeout(config.attackConfig.targetTimeoutMs!),
     });
     const timeMs = Date.now() - start;
 

--- a/lib/config-loader.ts
+++ b/lib/config-loader.ts
@@ -105,6 +105,8 @@ function validateAndNormalizeConfig(config: Config): Config {
     enableAdaptiveMultiTurn: true,
     maxAdaptiveTurns: 15,
     appTailoredCustomPromptCount: 0,
+    targetTimeoutMs: 30000,
+    llmTimeoutMs: 60000,
   };
   config.attackConfig = { ...defaults, ...config.attackConfig };
 

--- a/lib/llm-provider.ts
+++ b/lib/llm-provider.ts
@@ -125,8 +125,8 @@ async function createOpenAICompatibleChatCompletion(
 class OpenAIProvider implements LlmProvider {
   private client: OpenAI;
 
-  constructor() {
-    this.client = new OpenAI();
+  constructor(timeoutMs: number) {
+    this.client = new OpenAI({ timeout: timeoutMs });
   }
 
   async chat(options: ChatOptions): Promise<string> {
@@ -138,14 +138,16 @@ class OpenAIProvider implements LlmProvider {
 
 class AnthropicProvider implements LlmProvider {
   private apiKey: string;
+  private timeoutMs: number;
 
-  constructor() {
+  constructor(timeoutMs: number) {
     const key = process.env.ANTHROPIC_API_KEY;
     if (!key)
       throw new Error(
         "ANTHROPIC_API_KEY environment variable is required for anthropic provider",
       );
     this.apiKey = key;
+    this.timeoutMs = timeoutMs;
   }
 
   async chat(options: ChatOptions): Promise<string> {
@@ -180,6 +182,7 @@ class AnthropicProvider implements LlmProvider {
             "anthropic-version": "2023-06-01",
           },
           body: JSON.stringify(body),
+          signal: AbortSignal.timeout(this.timeoutMs),
         });
       } catch (fetchErr) {
         if (attempt < MAX_RETRIES) {
@@ -233,7 +236,7 @@ class AnthropicProvider implements LlmProvider {
 class OpenRouterProvider implements LlmProvider {
   private client: OpenAI;
 
-  constructor() {
+  constructor(timeoutMs: number) {
     const key = process.env.OPENROUTER_API_KEY;
     if (!key)
       throw new Error(
@@ -242,6 +245,7 @@ class OpenRouterProvider implements LlmProvider {
     this.client = new OpenAI({
       baseURL: "https://openrouter.ai/api/v1",
       apiKey: key,
+      timeout: timeoutMs,
       defaultHeaders: {
         "HTTP-Referer":
           process.env.OPENROUTER_SITE_URL || "https://github.com/red-team-ai",
@@ -260,7 +264,7 @@ class OpenRouterProvider implements LlmProvider {
 class TogetherAIProvider implements LlmProvider {
   private client: OpenAI;
 
-  constructor() {
+  constructor(timeoutMs: number) {
     const key = process.env.TOGETHER_API_KEY;
     if (!key)
       throw new Error(
@@ -269,6 +273,7 @@ class TogetherAIProvider implements LlmProvider {
     this.client = new OpenAI({
       baseURL: "https://api.together.xyz/v1",
       apiKey: key,
+      timeout: timeoutMs,
     });
   }
 
@@ -281,24 +286,25 @@ class TogetherAIProvider implements LlmProvider {
 
 const providerCache = new Map<string, LlmProvider>();
 
-function createProvider(name: string): LlmProvider {
-  if (providerCache.has(name)) {
-    return providerCache.get(name)!;
+function createProvider(name: string, timeoutMs: number): LlmProvider {
+  const cacheKey = `${name}:${timeoutMs}`;
+  if (providerCache.has(cacheKey)) {
+    return providerCache.get(cacheKey)!;
   }
 
   let provider: LlmProvider;
   switch (name) {
     case "openai":
-      provider = new OpenAIProvider();
+      provider = new OpenAIProvider(timeoutMs);
       break;
     case "anthropic":
-      provider = new AnthropicProvider();
+      provider = new AnthropicProvider(timeoutMs);
       break;
     case "openrouter":
-      provider = new OpenRouterProvider();
+      provider = new OpenRouterProvider(timeoutMs);
       break;
     case "together":
-      provider = new TogetherAIProvider();
+      provider = new TogetherAIProvider(timeoutMs);
       break;
     default:
       throw new Error(
@@ -306,18 +312,21 @@ function createProvider(name: string): LlmProvider {
       );
   }
 
-  providerCache.set(name, provider);
+  providerCache.set(cacheKey, provider);
   return provider;
 }
 
 /** Get the LLM provider for attack generation. */
 export function getLlmProvider(config: Config): LlmProvider {
-  return createProvider(config.attackConfig.llmProvider);
+  return createProvider(
+    config.attackConfig.llmProvider,
+    config.attackConfig.llmTimeoutMs!,
+  );
 }
 
 /** Get the LLM provider for the judge. Falls back to the attack provider if judgeProvider is not set. */
 export function getJudgeProvider(config: Config): LlmProvider {
   const judgeName =
     config.attackConfig.judgeProvider ?? config.attackConfig.llmProvider;
-  return createProvider(judgeName);
+  return createProvider(judgeName, config.attackConfig.llmTimeoutMs!);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -523,6 +523,10 @@ export interface Config {
     appTailoredCustomPromptCount?: number;
     /** Run an automated discovery round before attack rounds to probe the target and enrich sensitivePatterns. Default: false. */
     enableDiscovery?: boolean;
+    /** Per-request timeout for target agent and auth endpoint fetches, in ms. Default: 30000. */
+    targetTimeoutMs?: number;
+    /** Per-request timeout for LLM provider calls, in ms. Default: 60000. */
+    llmTimeoutMs?: number;
   };
 }
 

--- a/tests/attack-runner-timeout.test.ts
+++ b/tests/attack-runner-timeout.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, Server } from "http";
+import { executeAttack } from "../lib/attack-runner.js";
+import type { Config, Attack } from "../lib/types.js";
+
+let server: Server;
+let port: number;
+
+beforeAll(
+  () =>
+    new Promise<void>((resolve) => {
+      server = createServer(() => {
+        // never respond — client must time out
+      });
+      server.listen(0, "127.0.0.1", () => {
+        port = (server.address() as { port: number }).port;
+        resolve();
+      });
+    }),
+);
+
+afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+describe("executeAttack timeout", () => {
+  it("aborts a hanging target request within targetTimeoutMs", async () => {
+    const config = {
+      target: {
+        type: "http_agent",
+        baseUrl: `http://127.0.0.1:${port}`,
+        agentEndpoint: "/",
+        authEndpoint: "/login",
+      },
+      auth: { methods: [], jwtSecret: "", credentials: [], apiKeys: {} },
+      attackConfig: { targetTimeoutMs: 150 },
+    } as unknown as Config;
+
+    const attack: Attack = {
+      id: "t",
+      category: "auth_bypass",
+      name: "t",
+      description: "t",
+      authMethod: "none",
+      role: "",
+      payload: { message: "hi" },
+      expectation: "",
+      severity: "low",
+      isLlmGenerated: false,
+    };
+
+    const start = Date.now();
+    const result = await executeAttack(config, attack);
+    const elapsed = Date.now() - start;
+
+    expect(result.statusCode).toBe(0);
+    expect(elapsed).toBeGreaterThanOrEqual(140);
+    expect(elapsed).toBeLessThan(2000);
+  });
+});

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -76,6 +76,8 @@ describe("loadConfig", () => {
     expect(config.attackConfig.llmModel).toBe("gpt-4o");
     expect(config.attackConfig.enableLlmGeneration).toBe(true);
     expect(config.attackConfig.maxMultiTurnSteps).toBe(8);
+    expect(config.attackConfig.targetTimeoutMs).toBe(30000);
+    expect(config.attackConfig.llmTimeoutMs).toBe(60000);
   });
 
   it("allows overriding attackConfig defaults", () => {


### PR DESCRIPTION
## Summary

Fixes #29 — `fetch()` calls to the target agent, auth endpoint, and LLM providers had no timeout. One stuck request would freeze an entire red-team run until manually killed.

- `lib/attack-runner.ts` — `executeAttack` + `loginForToken` now use `AbortSignal.timeout(targetTimeoutMs)` (default 30s)
- `lib/llm-provider.ts` — OpenAI / OpenRouter / Together pass `timeout` to the SDK; Anthropic raw fetch uses `AbortSignal.timeout(llmTimeoutMs)` (default 60s). Provider cache keyed by `name:timeoutMs` so judge + attack providers with different timeouts stay independent.
- `lib/config-loader.ts` + `lib/types.ts` + `config.example.json` — new `attackConfig.targetTimeoutMs` / `llmTimeoutMs` fields, both optional with defaults

Aborted target requests return `statusCode: 0` with the error message (same path as other network failures), so existing response-analysis logic treats them as errors without code changes elsewhere.

### Scope

Covers the HTTP/auth/LLM paths named in the issue (`lib/attack-runner.ts`, `lib/llm-provider.ts`). The MCP transport (`lib/mcp/transport.ts`) and WebSocket target (`lib/websocket-attack-executor.ts`) are separate subsystems — happy to take those in a follow-up PR if you want them covered too.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 335/335 pass, including a new `tests/attack-runner-timeout.test.ts` that starts a hanging local HTTP server and asserts `executeAttack` aborts within `targetTimeoutMs`
- [x] `config-loader.test.ts` extended to assert the new defaults (30000/60000)
- [ ] Smoke-run `red-team.ts` against a real target once merged