### PR TITLE
Reject configs with empty apiKeys object (fixes #33)

### DIFF
--- a/lib/config-loader.ts
+++ b/lib/config-loader.ts
@@ -70,7 +70,10 @@ function validateAndNormalizeConfig(config: Config): Config {
     );
     config.target.applicationDetails = "";
   }
-  if (!config.auth?.credentials?.length && !config.auth?.apiKeys) {
+  if (
+    !config.auth?.credentials?.length &&
+    !Object.keys(config.auth?.apiKeys ?? {}).length
+  ) {
     throw new Error(
       "config: at least one auth method (credentials or apiKeys) is required",
     );

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -248,6 +248,36 @@ describe("loadConfig", () => {
     expect(() => loadConfig(path)).toThrow("at least one auth method");
   });
 
+  it("throws when credentials is empty and apiKeys is an empty object (#33)", () => {
+    const path = writeTestConfig(
+      tmpDir,
+      makeValidConfig({
+        auth: {
+          methods: ["jwt"],
+          jwtSecret: "s",
+          credentials: [],
+          apiKeys: {},
+        },
+      }),
+    );
+    expect(() => loadConfig(path)).toThrow("at least one auth method");
+  });
+
+  it("accepts empty credentials when apiKeys has at least one entry", () => {
+    const path = writeTestConfig(
+      tmpDir,
+      makeValidConfig({
+        auth: {
+          methods: ["api_key"],
+          jwtSecret: "s",
+          credentials: [],
+          apiKeys: { admin: "ak_admin_001" },
+        },
+      }),
+    );
+    expect(() => loadConfig(path)).not.toThrow();
+  });
+
   it("throws on non-existent config file", () => {
     expect(() => loadConfig("/nonexistent/path/config.json")).toThrow();
   });


### PR DESCRIPTION
## Summary

Fixes #33 — `loadConfig`'s auth-required check was `!config.auth?.apiKeys`, which is `false` for `{}` (empty object is truthy). Configs with `credentials: []` and `apiKeys: {}` slipped through validation and caused confusing downstream failures when no usable auth existed.

## Fix

One-line change in `lib/config-loader.ts`:

```ts
// before
if (!config.auth?.credentials?.length && !config.auth?.apiKeys) {
// after
if (
  !config.auth?.credentials?.length &&
  !Object.keys(config.auth?.apiKeys ?? {}).length
) {
```

Matches the suggested fix from the issue author. Both `undefined` and `{}` now fail the same way.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 336/336 pass (2 new regression tests in `tests/config-loader.test.ts`: empty-`{}` now throws, non-empty `apiKeys` with empty credentials still passes)