### PR TITLE
Add codebaseRepo support for remote white-box scanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN npm ci --omit=dev
 FROM node:20-slim
 WORKDIR /app
 
-# Install tsx globally for running TypeScript
+# Install git (needed for codebaseRepo cloning) and tsx
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN npm i -g tsx
 
 # Copy production dependencies
@@ -24,6 +25,7 @@ COPY policies/ ./policies/
 COPY lib/migrations/ ./lib/migrations/
 COPY compliance/ ./compliance/
 COPY config.example.json ./
+COPY examples/ ./examples/
 
 # Create report directory
 RUN mkdir -p report

--- a/config.json
+++ b/config.json
@@ -6,7 +6,9 @@
     "applicationDetails": "This is a small Next.js application that simulates an internal AI assistant with access to sensitive company systems, mainly for testing data exfiltration and prompt-injection behavior. The main route, src/app/page.tsx, presents it as a \"demo agentic app\" with JWT auth, deterministic RBAC, input/output guardrails, rate limiting, and audit logging.\n\nThe core API is src/app/api/exfil-test-agent/route.ts:313, which accepts a user message, resolves identity from JWT, API key, or a test role field, applies per-user rate limits, scans the prompt for risky input, then runs an OpenAI-driven tool-calling loop. The agent can use mock tools like read_file, db_query, read_repo, send_email, slack_dm, and read_inbox, but access is filtered by role through the ToolGateway in src/lib/gateway/tool-gateway.ts.\nThe tools do not hit real infrastructure; they return fake sensitive data from in-memory fixtures in src/data/fake-env.ts."
   },
   "codebasePath": null,
-  "codebaseGlob": "**/*.ts",
+  "codebaseRepo": "https://github.com/sundi133/demo-agentic-app.git",
+  "codebaseRepoBranch": "main",
+  "codebaseGlob": "**/*",
   "policyFile": "policies/strict.json",
   "customAttacksFile": "examples/custom-attacks.example.csv",
   "customAttacksDefaults": {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2682,14 +2682,14 @@
           html += '<div id="liveResultsContainer">' + buildLiveResultsHtml(liveResults) + '</div>';
         }
 
-        // Progress log
-        const progressLines = (data.progress || []).filter(p => p.phase !== "result").slice(-15);
+        // Progress log — preserve open/closed state across re-renders
+        const progressLines = (data.progress || []).filter(p => p.phase !== "result").slice(-30);
         if (progressLines.length > 0) {
-          html += '<details style="margin-top:12px;">' +
+          html += '<details' + (progressLogOpen ? ' open' : '') + ' style="margin-top:12px;" ontoggle="progressLogOpen=this.open">' +
             '<summary style="font-size:12px;font-weight:600;cursor:pointer;color:var(--text2);">Progress Log (' + (data.progressTotal || data.progress?.length || 0) + ' events)</summary>' +
-            '<div style="max-height:200px;overflow-y:auto;background:var(--surface);border-radius:6px;padding:10px;margin-top:8px;">';
+            '<div style="max-height:260px;overflow-y:auto;background:var(--surface);border-radius:6px;padding:10px;margin-top:8px;">';
           for (const p of progressLines) {
-            const phaseColor = {config:"#58a6ff",analyze:"#58a6ff",auth:"#58a6ff",discovery:"#d29922",attacks:"#f85149",refine:"#d29922",report:"#3fb950"}[p.phase] || "#8b949e";
+            const phaseColor = {config:"#58a6ff",analyze:"#58a6ff",auth:"#58a6ff",clone:"#d2a8ff",discovery:"#d29922",attacks:"#f85149",refine:"#d29922",report:"#3fb950",static:"#79c0ff"}[p.phase] || "#8b949e";
             html += '<div style="font-size:11px;font-family:monospace;padding:1px 0;"><span style="color:' + phaseColor + ';">[' + esc(p.phase) + ']</span> ' + esc(p.message).slice(0, 120) + '</div>';
           }
           html += '</div></details>';
@@ -7674,6 +7674,7 @@
       let liveExpandAll = false;
       let liveFilterVerdict = "";
       let liveFilterSeverity = "";
+      let progressLogOpen = false;
       const runDataCache = new Map();
 
       function pollRun(runId) {
@@ -7706,7 +7707,15 @@
 
             renderSidebarRuns();
             if (selectedRunId === runId) {
-              if (currentTab === "runs") renderRunsTab();
+              if (currentTab === "runs") {
+                // Targeted update: only re-render the inline detail panel, not the entire tab
+                const detailEl = document.getElementById("runDetailInline");
+                if (detailEl) {
+                  detailEl.innerHTML = buildRunDetailContent(runId, merged);
+                } else {
+                  renderRunsTab();
+                }
+              }
               else renderRunMainPanel(runId, merged);
             }
 

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -1,6 +1,8 @@
 import { createServer, type IncomingMessage } from "node:http";
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync, readdirSync, rmSync, mkdtempSync } from "node:fs";
 import { join, extname } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { loadConfig } from "../lib/config-loader.js";
 import { loadConfigFromObject } from "../lib/config-loader.js";
@@ -125,13 +127,57 @@ const jobs = new Map<string, Job>();
 let activeRuns = 0;
 const MAX_CONCURRENT = parseInt(process.env.MAX_CONCURRENT_RUNS || "100", 10);
 
+/** Clone a git repo into a temp dir for white-box analysis. Returns the temp path. */
+function cloneCodebaseRepo(config: Config, jobId: string): string | null {
+  if (!config.codebaseRepo || config.codebasePath) return null;
+
+  const tmpDir = mkdtempSync(join(tmpdir(), `redteam-src-${jobId.slice(0, 8)}-`));
+  let repoUrl = config.codebaseRepo;
+
+  // Inject token for private repos: https://token@github.com/org/repo.git
+  // Token from config takes precedence, falls back to CODEBASE_REPO_TOKEN env var
+  const token = config.codebaseRepoToken || process.env.CODEBASE_REPO_TOKEN || "";
+  if (token && repoUrl.startsWith("https://")) {
+    repoUrl = repoUrl.replace("https://", `https://${token}@`);
+  }
+
+  const branch = config.codebaseRepoBranch || "";
+  const branchFlag = branch ? `--branch ${branch}` : "";
+
+  console.log(`  Cloning ${config.codebaseRepo} into ${tmpDir} ...`);
+  execSync(`git clone --depth 1 ${branchFlag} ${repoUrl} ${tmpDir}`, {
+    stdio: "pipe",
+    timeout: 120_000, // 2 min max
+  });
+  console.log(`  Clone complete: ${tmpDir}`);
+  return tmpDir;
+}
+
 async function startJob(job: Job): Promise<void> {
   activeRuns++;
   job.status = "running";
   const ac = new AbortController();
   job.abortController = ac;
 
+  let clonedDir: string | null = null;
   try {
+    // Clone repo if codebaseRepo is set and codebasePath is not
+    if (job.config.codebaseRepo && !job.config.codebasePath) {
+      job.progress.push({ phase: "clone", message: `Cloning ${job.config.codebaseRepo} (branch: ${job.config.codebaseRepoBranch || "HEAD"})...` });
+      try {
+        clonedDir = cloneCodebaseRepo(job.config, job.id);
+        if (clonedDir) {
+          job.config.codebasePath = clonedDir;
+          job.progress.push({ phase: "clone", message: `Clone successful → white-box analysis enabled` });
+        }
+      } catch (cloneErr) {
+        const msg = cloneErr instanceof Error ? cloneErr.message : String(cloneErr);
+        job.progress.push({ phase: "clone", message: `Clone failed: ${msg.slice(0, 150)} — falling back to black-box mode` });
+        console.error("  Clone failed:", msg);
+        // Continue without source code (black-box mode)
+      }
+    }
+
     const result = await runRedTeam(
       job.config,
       (p) => {
@@ -244,6 +290,10 @@ async function startJob(job: Job): Promise<void> {
     }
   } finally {
     job.abortController = undefined;
+    // Clean up cloned repo temp dir
+    if (clonedDir) {
+      try { rmSync(clonedDir, { recursive: true, force: true }); } catch {}
+    }
     // Only decrement if not already decremented by cancel handler
     if (job.status !== "cancelled") {
       activeRuns = Math.max(0, activeRuns - 1);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -433,6 +433,12 @@ export interface Config {
     infra?: TargetInfra;
   };
   codebasePath?: string | null;
+  /** Git repo URL to clone for white-box analysis (used when codebasePath is not available, e.g. remote deployment). */
+  codebaseRepo?: string | null;
+  /** Branch/tag to checkout when cloning codebaseRepo (default: HEAD). */
+  codebaseRepoBranch?: string;
+  /** Git auth token for private repos (appended as https://token@host/...). */
+  codebaseRepoToken?: string;
   codebaseGlob: string;
   /** Path to the judge policy JSON file (default: "policies/default.json"). */
   policyFile?: string;


### PR DESCRIPTION
- Clone git repos at scan time into per-run temp dirs (no conflicts)
- Support private repos via codebaseRepoToken or CODEBASE_REPO_TOKEN env
- Show clone status in progress log, graceful fallback to black-box
- Fix progress log flickering (targeted DOM update instead of full re-render)
- Install git in Docker image, copy examples/ for customAttacksFile