### PR TITLE
Add custom LLM provider for internal endpoints + LLM providers docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd wb-red-team && npm install
 
 # 2. Set your LLM key (one of)
 cp .env.example .env
-# Edit .env — add at least one: ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or TOGETHER_API_KEY
+# Edit .env — add at least one LLM key: ANTHROPIC_API_KEY, OPENAI_API_KEY, TOGETHER_API_KEY, AZURE_OPENAI_API_KEY, or CUSTOM_LLM_BASE_URL
 
 # 3. Generate config interactively
 npm run gen:interactive
@@ -471,14 +471,66 @@ Deploy anywhere — AWS, GCP, Azure, Railway, on-prem, or any environment that r
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ANTHROPIC_API_KEY` | Yes (one LLM key) | LLM provider for attack generation and judging |
-| `OPENROUTER_API_KEY` | No | Alternative LLM provider |
+| `ANTHROPIC_API_KEY` | Yes (one LLM key) | Anthropic provider |
+| `OPENAI_API_KEY` | No | OpenAI provider |
+| `OPENROUTER_API_KEY` | No | OpenRouter provider |
 | `TOGETHER_API_KEY` | No | Together AI provider |
+| `AZURE_OPENAI_API_KEY` | No | Azure OpenAI provider |
+| `AZURE_OPENAI_ENDPOINT` | With Azure key | Azure endpoint (e.g. `https://myresource.openai.azure.com`) |
+| `AZURE_OPENAI_API_VERSION` | No | Azure API version (default: `2024-06-01`) |
+| `CUSTOM_LLM_BASE_URL` | No | Custom OpenAI-compatible endpoint (Trussed AI, vLLM, LiteLLM, Ollama) |
+| `CUSTOM_LLM_API_KEY` | With custom URL | API key for custom endpoint |
+| `CODEBASE_REPO_TOKEN` | No | Git token for private repo white-box scanning |
 | `DATABASE_URL` | No | Postgres connection. Enables enterprise features |
 | `MASTER_ENCRYPTION_KEY` | With DB | 64 hex chars. Encrypts report data at rest |
 | `AUTH_MODE` | No | `dev` = no login required. Omit for OIDC auth |
 | `CLERK_PUBLISHABLE_KEY` | No | Clerk publishable key for browser SSO |
 | `MAX_CONCURRENT_RUNS` | No | Max parallel scans (default: 100) |
+
+### LLM Providers
+
+Use any combination of providers for attack generation (`llmProvider`) and judging (`judgeProvider`):
+
+| Provider | Config value | Models | Env vars |
+|----------|-------------|--------|----------|
+| **Anthropic** | `anthropic` | `claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001` | `ANTHROPIC_API_KEY` |
+| **OpenAI** | `openai` | `gpt-4o`, `gpt-4o-mini`, `gpt-4.1-mini` | `OPENAI_API_KEY` |
+| **Together AI** | `together` | `deepseek-ai/DeepSeek-V3`, `meta-llama/Llama-3-70b` | `TOGETHER_API_KEY` |
+| **OpenRouter** | `openrouter` | Any model on OpenRouter | `OPENROUTER_API_KEY` |
+| **Azure OpenAI** | `azure` | Your deployment name | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT` |
+| **Custom** | `custom` | Any model name | `CUSTOM_LLM_BASE_URL`, `CUSTOM_LLM_API_KEY` |
+
+Mix and match — e.g. use Together for cheap attack generation and Anthropic for accurate judging:
+
+```json
+{
+  "attackConfig": {
+    "llmProvider": "together",
+    "llmModel": "deepseek-ai/DeepSeek-V3",
+    "judgeProvider": "anthropic",
+    "judgeModel": "claude-sonnet-4-20250514"
+  }
+}
+```
+
+**Custom provider** works with any OpenAI-compatible endpoint (Trussed AI, vLLM, LiteLLM, Ollama, etc.):
+
+```bash
+# .env
+CUSTOM_LLM_BASE_URL=https://your-internal-gateway.com/provider/generic
+CUSTOM_LLM_API_KEY=your-key
+```
+
+```json
+{
+  "attackConfig": {
+    "llmProvider": "custom",
+    "llmModel": "your-deployment-name",
+    "judgeProvider": "custom",
+    "judgeModel": "your-deployment-name"
+  }
+}
+```
 
 **API keys for programmatic access:**
 

--- a/lib/llm-provider.ts
+++ b/lib/llm-provider.ts
@@ -309,6 +309,30 @@ class AzureOpenAIProvider implements LlmProvider {
   }
 }
 
+// ── Custom OpenAI-compatible Provider ──
+// For internal endpoints like Trussed AI, vLLM, LiteLLM, Ollama, etc.
+// Env: CUSTOM_LLM_API_KEY, CUSTOM_LLM_BASE_URL
+
+class CustomProvider implements LlmProvider {
+  private client: OpenAI;
+
+  constructor() {
+    const baseURL = process.env.CUSTOM_LLM_BASE_URL;
+    if (!baseURL)
+      throw new Error(
+        "CUSTOM_LLM_BASE_URL environment variable is required for custom provider (e.g. https://your-internal-gateway.com/v1)",
+      );
+    this.client = new OpenAI({
+      apiKey: process.env.CUSTOM_LLM_API_KEY || "no-key",
+      baseURL,
+    });
+  }
+
+  async chat(options: ChatOptions): Promise<string> {
+    return createOpenAICompatibleChatCompletion(this.client, options);
+  }
+}
+
 // ── Factory ──
 
 const providerCache = new Map<string, LlmProvider>();
@@ -335,9 +359,12 @@ function createProvider(name: string): LlmProvider {
     case "azure":
       provider = new AzureOpenAIProvider();
       break;
+    case "custom":
+      provider = new CustomProvider();
+      break;
     default:
       throw new Error(
-        `Unknown LLM provider: "${name}". Use "openai", "anthropic", "openrouter", "together", or "azure".`,
+        `Unknown LLM provider: "${name}". Use "openai", "anthropic", "openrouter", "together", "azure", or "custom".`,
       );
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -479,10 +479,10 @@ export interface Config {
     maxAttacksPerCategory: number;
     concurrency: number;
     delayBetweenRequestsMs: number;
-    llmProvider: "openai" | "anthropic" | "openrouter" | "together" | "azure";
+    llmProvider: "openai" | "anthropic" | "openrouter" | "together" | "azure" | "custom";
     llmModel: string;
     /** LLM provider for the judge (defaults to llmProvider if not set). */
-    judgeProvider?: "openai" | "anthropic" | "openrouter" | "together" | "azure";
+    judgeProvider?: "openai" | "anthropic" | "openrouter" | "together" | "azure" | "custom";
     judgeModel?: string;
     enableLlmGeneration: boolean;
     maxMultiTurnSteps: number;

--- a/scripts/mock-trussed-server.ts
+++ b/scripts/mock-trussed-server.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env npx tsx
+/**
+ * Mock Trussed AI gateway — OpenAI-compatible chat completions endpoint.
+ * Simulates an internal corporate LLM proxy for testing custom provider.
+ *
+ * Usage: npx tsx scripts/mock-trussed-server.ts [port]
+ *
+ * Test:
+ *   curl -X POST http://localhost:9000/provider/generic/chat/completions \
+ *     -H "Content-Type: application/json" \
+ *     -H "Authorization: Bearer test-key" \
+ *     -d '{"model":"AISolutions6GVASAAPTUs","messages":[{"role":"user","content":"hello"}]}'
+ */
+
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+
+const PORT = parseInt(process.argv[2] || "9000", 10);
+
+const server = createServer((req, res) => {
+  // Health check
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+    return;
+  }
+
+  // Chat completions — matches /provider/generic/chat/completions or /v1/chat/completions
+  if (req.method === "POST" && (req.url?.includes("/chat/completions"))) {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      let model = "AISolutions6GVASAAPTUs";
+      let userMessage = "";
+      let systemMessage = "";
+
+      try {
+        const parsed = JSON.parse(body);
+        model = parsed.model || model;
+        const messages = parsed.messages || [];
+        const system = messages.find((m: any) => m.role === "system");
+        const user = messages.filter((m: any) => m.role === "user").pop();
+        if (system?.content) systemMessage = system.content;
+        if (user?.content) userMessage = user.content;
+      } catch {}
+
+      // Generate a contextual response based on the user message
+      let responseContent: string;
+      const lower = userMessage.toLowerCase();
+
+      if (lower.includes("capital")) {
+        responseContent = "The capital of the United States is Washington, D.C.";
+      } else if (lower.includes("policy") || lower.includes("insurance")) {
+        responseContent = "I can help you with your insurance policy. Your Auto policy POL-12345 is currently active with comprehensive coverage. Please note I cannot share sensitive information like SSN or internal credentials.";
+      } else if (lower.includes("ignore") || lower.includes("system prompt") || lower.includes("instructions")) {
+        responseContent = "I'm sorry, but I cannot ignore my safety guidelines or reveal my system instructions. I'm here to help with legitimate insurance-related questions.";
+      } else if (lower.includes("secret") || lower.includes("password") || lower.includes("key") || lower.includes("token")) {
+        responseContent = "I cannot share any credentials, API keys, passwords, or other sensitive information. This is against our security policies.";
+      } else {
+        responseContent = `Thank you for your question. As an insurance assistant, I'm designed to help with policy inquiries, claims, and coverage questions. How can I assist you today?`;
+      }
+
+      const response = {
+        id: `chatcmpl-${randomUUID().slice(0, 12)}`,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: responseContent,
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: {
+          prompt_tokens: Math.ceil((systemMessage.length + userMessage.length) / 4),
+          completion_tokens: Math.ceil(responseContent.length / 4),
+          total_tokens: Math.ceil((systemMessage.length + userMessage.length + responseContent.length) / 4),
+        },
+      };
+
+      console.log(`  [${new Date().toISOString()}] ${model} — "${userMessage.slice(0, 60)}..." → ${responseContent.slice(0, 50)}...`);
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(response));
+    });
+    return;
+  }
+
+  // Models list
+  if (req.method === "GET" && req.url?.includes("/models")) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      data: [
+        { id: "AISolutions6GVASAAPTUs", object: "model", owned_by: "trussed-ai" },
+        { id: "AISolutions6GVASAAgpt-4.1-mini", object: "model", owned_by: "trussed-ai" },
+      ],
+    }));
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Not found" }));
+});
+
+server.listen(PORT, () => {
+  console.log(`\n  Mock Trussed AI Gateway → http://localhost:${PORT}`);
+  console.log(`  Endpoint: POST /provider/generic/chat/completions`);
+  console.log(`  Models: AISolutions6GVASAAPTUs, AISolutions6GVASAAgpt-4.1-mini`);
+  console.log(`\n  Test:`);
+  console.log(`    curl -X POST http://localhost:${PORT}/provider/generic/chat/completions \\`);
+  console.log(`      -H "Content-Type: application/json" \\`);
+  console.log(`      -H "Authorization: Bearer test-key" \\`);
+  console.log(`      -d '{"model":"AISolutions6GVASAAPTUs","messages":[{"role":"user","content":"hello"}]}'`);
+  console.log(`\n  Press Ctrl+C to stop\n`);
+});


### PR DESCRIPTION
- New "custom" provider for OpenAI-compatible gateways (Trussed AI, vLLM, LiteLLM, Ollama) via CUSTOM_LLM_BASE_URL + CUSTOM_LLM_API_KEY
- Add mock Trussed AI server for local testing
- Add LLM Providers reference table to README with all 6 providers
- Update env vars table with Azure, custom, and codebase token