### PR TITLE
feat: Add explicit auth mode and request timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ ANTHROPIC_API_KEY=
 # OPENROUTER_API_KEY=
 # TOGETHER_API_KEY=
 
+# Request safety defaults
+# Scan configs can also set attackConfig.targetTimeoutMs and attackConfig.llmTimeoutMs.
+# TARGET_TIMEOUT_MS=30000
+# LLM_TIMEOUT_MS=60000
+
 # ── Enterprise Mode (optional — skip for quick local testing) ──
 # DATABASE_URL=postgres://redteam:redteam_dev@postgres:5432/redteam
 # MASTER_ENCRYPTION_KEY=   # Generate with: openssl rand -hex 32

--- a/config-quick-test.json
+++ b/config-quick-test.json
@@ -19,6 +19,8 @@
   "codebaseGlob": "**/*.ts",
   "policyFile": "policies/strict.json",
   "auth": {
+    "mode": "none",
+    "reason": "Local unauthenticated endpoint testing only",
     "methods": ["none"],
     "jwtSecret": "not-needed",
     "credentials": [],
@@ -53,6 +55,8 @@
     "maxAttacksPerCategory": 2,
     "concurrency": 1,
     "delayBetweenRequestsMs": 200,
+    "targetTimeoutMs": 30000,
+    "llmTimeoutMs": 60000,
     "llmProvider": "openrouter",
     "llmModel": "z-ai/glm-5.1",
     "judgeProvider": "anthropic",

--- a/config.example.json
+++ b/config.example.json
@@ -16,6 +16,7 @@
     "role": "admin"
   },
   "auth": {
+    "mode": "jwt",
     "methods": ["jwt", "api_key", "body_role"],
     "jwtSecret": "demo-agentic-app-jwt-secret-key-change-in-prod",
     "credentials": [
@@ -81,6 +82,8 @@
     "maxAttacksPerCategory": 15,
     "concurrency": 2,
     "delayBetweenRequestsMs": 200,
+    "targetTimeoutMs": 30000,
+    "llmTimeoutMs": 60000,
     "llmProvider": "anthropic",
     "llmModel": "claude-opus-4-5-20251101",
     "judgeProvider": "openai",

--- a/lib/attack-runner.ts
+++ b/lib/attack-runner.ts
@@ -8,6 +8,30 @@ import { formatErrorDetails } from "./error-utils.js";
 // Cache JWT tokens per role
 const tokenCache = new Map<string, string>();
 
+function targetTimeoutMs(config: Config): number {
+  return config.attackConfig.targetTimeoutMs ?? 30_000;
+}
+
+async function fetchWithTargetTimeout(
+  config: Config,
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const timeoutMs = targetTimeoutMs(config);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Target request timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export async function preAuthenticate(config: Config): Promise<void> {
   const adapter = getTargetAdapter(config);
   if (adapter) {
@@ -34,7 +58,7 @@ async function loginForToken(
   cred: Credential,
 ): Promise<string> {
   const url = `${config.target.baseUrl}${config.target.authEndpoint}`;
-  const res = await fetch(url, {
+  const res = await fetchWithTargetTimeout(config, url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email: cred.email, password: cred.password }),
@@ -331,7 +355,7 @@ export async function executeAttack(
 
   const start = Date.now();
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithTargetTimeout(config, url, {
       method,
       headers: finalHeaders,
       body: requestBody,

--- a/lib/config-loader.ts
+++ b/lib/config-loader.ts
@@ -13,8 +13,21 @@ function findDuplicates(values: string[] | undefined): string[] {
     .map(([value]) => value);
 }
 
+function positiveEnvNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function validateAndNormalizeConfig(config: Config): Config {
   config.target.type = config.target.type ?? "http_agent";
+  if (!config.auth) {
+    throw new Error("config: auth is required");
+  }
+  config.auth.methods = config.auth.methods ?? [];
+  config.auth.credentials = config.auth.credentials ?? [];
+  config.auth.apiKeys = config.auth.apiKeys ?? {};
 
   // Validate required fields
   if (config.target.type === "http_agent") {
@@ -70,10 +83,28 @@ function validateAndNormalizeConfig(config: Config): Config {
     );
     config.target.applicationDetails = "";
   }
-  if (!config.auth?.credentials?.length && !config.auth?.apiKeys) {
+  const explicitAuthMode =
+    config.auth.mode ??
+    (config.auth.methods?.includes("none") ? "none" : undefined);
+  const apiKeyCount = Object.keys(config.auth.apiKeys ?? {}).length;
+  const credentialCount = config.auth.credentials?.length ?? 0;
+  config.auth.mode =
+    explicitAuthMode ??
+    (config.auth.methods?.includes("jwt")
+      ? "jwt"
+      : apiKeyCount > 0
+        ? "api_key"
+        : credentialCount > 0
+          ? "login"
+          : undefined);
+
+  if (config.auth.mode !== "none" && credentialCount === 0 && apiKeyCount === 0) {
     throw new Error(
-      "config: at least one auth method (credentials or apiKeys) is required",
+      'config: at least one auth method (credentials or apiKeys) is required, or set auth.mode="none" for authorized local unauthenticated testing',
     );
+  }
+  if (config.auth.mode === "none" && !config.auth.methods.includes("none")) {
+    config.auth.methods = [...config.auth.methods, "none"];
   }
   if (!config.sensitivePatterns?.length) {
     config.sensitivePatterns = [];
@@ -94,6 +125,8 @@ function validateAndNormalizeConfig(config: Config): Config {
     maxAttacksPerCategory: 15,
     concurrency: 3,
     delayBetweenRequestsMs: 200,
+    targetTimeoutMs: positiveEnvNumber("TARGET_TIMEOUT_MS", 30_000),
+    llmTimeoutMs: positiveEnvNumber("LLM_TIMEOUT_MS", 60_000),
     llmProvider: "openai",
     llmModel: "gpt-4o",
     enableLlmGeneration: true,
@@ -107,6 +140,15 @@ function validateAndNormalizeConfig(config: Config): Config {
     appTailoredCustomPromptCount: 0,
   };
   config.attackConfig = { ...defaults, ...config.attackConfig };
+
+  for (const [field, value] of [
+    ["targetTimeoutMs", config.attackConfig.targetTimeoutMs],
+    ["llmTimeoutMs", config.attackConfig.llmTimeoutMs],
+  ] as const) {
+    if (value != null && (!Number.isFinite(value) || value <= 0)) {
+      throw new Error(`config: attackConfig.${field} must be a positive number`);
+    }
+  }
 
   const duplicateCategories = findDuplicates(
     config.attackConfig.enabledCategories,

--- a/lib/llm-provider.ts
+++ b/lib/llm-provider.ts
@@ -13,6 +13,7 @@ export interface ChatOptions {
   messages: ChatMessage[];
   temperature?: number;
   maxTokens?: number;
+  timeoutMs?: number;
   /** Request JSON output from the model (OpenAI/OpenRouter only). */
   responseFormat?: "json_object";
 }
@@ -103,6 +104,7 @@ async function createOpenAICompatibleChatCompletion(
         requestConfig,
         initialOmitTemperature,
       ),
+      options.timeoutMs ? { timeout: options.timeoutMs } : undefined,
     );
     return response.choices[0]?.message?.content?.trim() ?? "";
   } catch (error) {
@@ -130,6 +132,7 @@ async function createOpenAICompatibleChatCompletion(
         requestConfig,
         initialOmitTemperature || retryWithoutTemperature,
       ),
+      options.timeoutMs ? { timeout: options.timeoutMs } : undefined,
     );
     return response.choices[0]?.message?.content?.trim() ?? "";
   }
@@ -192,6 +195,10 @@ class AnthropicProvider implements LlmProvider {
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       let response: Response;
+      const controller = options.timeoutMs ? new AbortController() : undefined;
+      const timer = options.timeoutMs
+        ? setTimeout(() => controller?.abort(), options.timeoutMs)
+        : undefined;
       try {
         response = await fetch("https://api.anthropic.com/v1/messages", {
           method: "POST",
@@ -201,8 +208,14 @@ class AnthropicProvider implements LlmProvider {
             "anthropic-version": "2023-06-01",
           },
           body: JSON.stringify(body),
+          signal: controller?.signal,
         });
       } catch (fetchErr) {
+        if (fetchErr instanceof Error && fetchErr.name === "AbortError") {
+          throw new Error(
+            `Anthropic API timeout after ${options.timeoutMs}ms`,
+          );
+        }
         if (attempt < MAX_RETRIES) {
           const delayMs = RETRY_DELAYS_MS[attempt];
           console.warn(
@@ -214,6 +227,8 @@ class AnthropicProvider implements LlmProvider {
         throw new Error(
           `Anthropic API network error after ${MAX_RETRIES} retries: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`,
         );
+      } finally {
+        if (timer) clearTimeout(timer);
       }
 
       if (
@@ -429,20 +444,38 @@ function createProvider(
 
 /** Get the LLM provider for attack generation. */
 export function getLlmProvider(config: Config): LlmProvider {
-  return createProvider(config.attackConfig.llmProvider, {
+  const provider = createProvider(config.attackConfig.llmProvider, {
     guardrails: config.attackConfig.llmGuardrails,
   });
+  const timeoutMs = config.attackConfig.llmTimeoutMs;
+  return {
+    chat(options) {
+      return provider.chat({
+        ...options,
+        timeoutMs: options.timeoutMs ?? timeoutMs,
+      });
+    },
+  };
 }
 
 /** Get the LLM provider for the judge. Falls back to the attack provider if judgeProvider is not set. */
 export function getJudgeProvider(config: Config): LlmProvider {
   const judgeName =
     config.attackConfig.judgeProvider ?? config.attackConfig.llmProvider;
-  return createProvider(judgeName, {
+  const provider = createProvider(judgeName, {
     guardrails:
       config.attackConfig.judgeGuardrails ??
       (judgeName === config.attackConfig.llmProvider
         ? config.attackConfig.llmGuardrails
         : undefined),
   });
+  const timeoutMs = config.attackConfig.llmTimeoutMs;
+  return {
+    chat(options) {
+      return provider.chat({
+        ...options,
+        timeoutMs: options.timeoutMs ?? timeoutMs,
+      });
+    },
+  };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -445,6 +445,10 @@ export interface Config {
   /** Path to the judge policy JSON file (default: "policies/default.json"). */
   policyFile?: string;
   auth: {
+    /** Explicit auth mode. Use "none" only for authorized local unauthenticated testing. */
+    mode?: "none" | "api_key" | "jwt" | "login" | "custom";
+    /** Optional human-readable justification when auth.mode is "none". */
+    reason?: string;
     methods: string[];
     jwtSecret: string;
     credentials: Credential[];
@@ -481,6 +485,10 @@ export interface Config {
     maxAttacksPerCategory: number;
     concurrency: number;
     delayBetweenRequestsMs: number;
+    /** Max time to wait for target HTTP/auth requests before returning an infrastructure ERROR. */
+    targetTimeoutMs?: number;
+    /** Max time to wait for attack-generation/judge LLM calls. */
+    llmTimeoutMs?: number;
     llmProvider: "openai" | "anthropic" | "openrouter" | "together" | "azure" | "custom";
     llmModel: string;
     /** Optional request-level guardrails array for attack generation LLM calls. */

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -73,6 +73,8 @@ describe("loadConfig", () => {
     expect(config.attackConfig.maxAttacksPerCategory).toBe(15);
     expect(config.attackConfig.concurrency).toBe(3);
     expect(config.attackConfig.delayBetweenRequestsMs).toBe(200);
+    expect(config.attackConfig.targetTimeoutMs).toBe(30000);
+    expect(config.attackConfig.llmTimeoutMs).toBe(60000);
     expect(config.attackConfig.llmModel).toBe("gpt-4o");
     expect(config.attackConfig.enableLlmGeneration).toBe(true);
     expect(config.attackConfig.maxMultiTurnSteps).toBe(8);
@@ -233,7 +235,7 @@ describe("loadConfig", () => {
     expect(() => loadConfig(path)).toThrow("target.agentEndpoint is required");
   });
 
-  it("throws on missing auth credentials and apiKeys", () => {
+  it("throws on missing auth credentials and apiKeys without explicit auth.mode none", () => {
     const path = writeTestConfig(
       tmpDir,
       makeValidConfig({
@@ -245,7 +247,26 @@ describe("loadConfig", () => {
         },
       }),
     );
-    expect(() => loadConfig(path)).toThrow("at least one auth method");
+    expect(() => loadConfig(path)).toThrow("auth.mode=\"none\"");
+  });
+
+  it("allows explicit unauthenticated local testing with auth.mode none", () => {
+    const path = writeTestConfig(
+      tmpDir,
+      makeValidConfig({
+        auth: {
+          mode: "none",
+          reason: "Local unauthenticated endpoint testing only",
+          methods: ["none"],
+          jwtSecret: "not-used",
+          credentials: [],
+          apiKeys: {},
+        },
+      }),
+    );
+    const config = loadConfig(path);
+    expect(config.auth.mode).toBe("none");
+    expect(config.auth.methods).toContain("none");
   });
 
   it("throws on non-existent config file", () => {


### PR DESCRIPTION
﻿## Summary

Adds explicit config safety controls for authorized unauthenticated targets and bounded request timeouts for both target HTTP calls and LLM provider calls. This removes two reliability footguns from scan execution: configs with no credentials now need to intentionally declare `auth.mode="none"`, and slow or hung target/LLM requests can no longer block a run indefinitely.

### Changes

1. **Explicit Auth Mode** (`auth.mode` in `lib/types.ts` and `lib/config-loader.ts`) — Adds a first-class auth mode with `none`, `api_key`, `jwt`, `login`, and `custom` options. Unauthenticated testing is still supported, but it must now be explicit via `auth.mode: "none"` or the existing `methods: ["none"]` compatibility path.

2. **Safer Auth Validation** (`validateAndNormalizeConfig()` in `lib/config-loader.ts`) — Normalizes `auth.methods`, `auth.credentials`, and `auth.apiKeys` before validation. Configs with no credentials/API keys now throw a clear message that explains how to intentionally opt into unauthenticated local testing.

3. **Target Request Timeouts** (`lib/attack-runner.ts`) — Wraps target login and attack HTTP requests in an `AbortController` timeout. The default is 30 seconds and can be overridden per config with `attackConfig.targetTimeoutMs` or globally with `TARGET_TIMEOUT_MS`.

4. **LLM Request Timeouts** (`lib/llm-provider.ts`) — Adds `timeoutMs` to provider chat options and applies `attackConfig.llmTimeoutMs` to attack-generation and judge calls. OpenAI-compatible providers use the SDK timeout option; Anthropic fetch calls use `AbortController`.

5. **Sample Config + Env Defaults** (`.env.example`, `config.example.json`, `config-quick-test.json`) — Documents the timeout env vars and updates sample configs with explicit auth mode plus target/LLM timeout values.

6. **Regression Coverage** (`tests/config-loader.test.ts`) — Covers default timeout normalization, clearer missing-auth errors, and explicit `auth.mode: "none"` acceptance.

### Files Changed

| File | Change |
|------|--------|
| `lib/types.ts` | Adds `auth.mode`, `auth.reason`, `attackConfig.targetTimeoutMs`, and `attackConfig.llmTimeoutMs` |
| `lib/config-loader.ts` | Normalizes auth objects, validates explicit unauthenticated mode, adds env-backed timeout defaults |
| `lib/attack-runner.ts` | Adds target request timeout wrapper for login and attack execution fetches |
| `lib/llm-provider.ts` | Adds LLM timeout support for OpenAI-compatible and Anthropic providers |
| `.env.example` | Documents `TARGET_TIMEOUT_MS` and `LLM_TIMEOUT_MS` |
| `config.example.json` | Adds explicit JWT mode and timeout defaults |
| `config-quick-test.json` | Adds explicit unauthenticated mode, reason, and timeout defaults |
| `tests/config-loader.test.ts` | Adds regression coverage for timeout defaults and explicit unauthenticated configs |

---

## Why Explicit Auth Mode + Timeouts Are Better Than Implicit Defaults

The scanner is often used against local demo agents, staging endpoints, and intentionally unauthenticated test services. Before this change, a config with no credentials could be ambiguous: either the user forgot auth material, or they really intended to test an unauthenticated endpoint.

### 1. Missing Auth Is Now an Intentional Choice

| Scenario | Before | After |
|----------|--------|-------|
| Forgot credentials | Generic missing auth error | Clear error with `auth.mode="none"` escape hatch |
| Local unauthenticated test | Relied on empty credentials/API keys | Explicit `auth.mode: "none"` with optional reason |
| Legacy `methods: ["none"]` config | Accepted indirectly | Still accepted and normalized |
| JWT/API key/login config | Inferred from available material | Still inferred when credentials/API keys exist |

### 2. Runs Fail Fast Instead of Hanging

Target endpoints and LLM providers can stall during real red-team runs because of network issues, overloaded test systems, provider incidents, or broken streaming behavior. Bounded request timeouts convert those hangs into normal `ERROR` outcomes that the runner can report and continue from.

### 3. Config-Level Overrides Keep Different Environments Flexible

The defaults are conservative for local use: 30 seconds for target requests and 60 seconds for LLM calls. Longer-running staging agents can override these per scan config without changing code, while CI can set env-wide defaults.

---

## How It Was Tested

### 1. Config Loader Regression Tests

Ran the focused config-loader suite:

```bash
npm.cmd test -- tests/config-loader.test.ts
```

Result: 15 tests passed.

### 2. TypeScript Verification

Ran the project typecheck:

```bash
npm.cmd run typecheck
```

Result: passed.

### 3. Patch Hygiene

Ran whitespace/conflict-marker verification:

```bash
git diff --check
```

Result: passed.

## Test plan

- [x] Default `attackConfig.targetTimeoutMs` is set to 30000
- [x] Default `attackConfig.llmTimeoutMs` is set to 60000
- [x] Configs with no credentials/API keys fail unless unauthenticated mode is explicit
- [x] `auth.mode: "none"` configs are accepted and normalize `methods` to include `none`
- [x] Target login and attack HTTP requests use timeout-aware fetches
- [x] LLM provider calls receive the configured timeout
- [x] OpenAI-compatible providers pass timeout through the SDK request options
- [x] Anthropic provider aborts timed-out fetch calls with a clear timeout error
- [x] TypeScript compilation passes
