### PR TITLE
feat: Add remediation plans to security reports

### DIFF
--- a/lib/remediation-planner.ts
+++ b/lib/remediation-planner.ts
@@ -1,0 +1,221 @@
+import type {
+  AffectedFile,
+  AttackCategory,
+  AttackResult,
+  RemediationPlan,
+} from "./types.js";
+
+const CATEGORY_ROOT_CAUSES: Partial<Record<AttackCategory, string>> = {
+  auth_bypass:
+    "Authentication or token validation accepted a request that should not be trusted.",
+  rbac_bypass:
+    "Authorization checks did not consistently enforce the requested user's role or tenant boundary.",
+  data_exfiltration:
+    "The agent could combine read access with an unsafe disclosure path.",
+  sensitive_data:
+    "Sensitive data reached the model response or tool-call side channel without adequate redaction.",
+  pii_disclosure:
+    "PII handling or output filtering did not prevent disclosure in the agent response.",
+  prompt_injection:
+    "The model treated user-controlled instructions as higher priority than system or developer policy.",
+  indirect_prompt_injection:
+    "Untrusted retrieved/tool content was allowed to influence model instructions.",
+  tool_misuse:
+    "Tool selection or tool parameter authorization allowed an unsafe operation.",
+  tool_chain_hijack:
+    "The agent could chain otherwise legitimate tools into an unsafe workflow.",
+  rate_limit:
+    "The target did not enforce throttling consistently for repeated requests.",
+  output_evasion:
+    "Output scanning failed to catch transformed, encoded, or partial unsafe content.",
+  sql_injection:
+    "User-controlled input appears able to influence database-query construction.",
+  shell_injection:
+    "User-controlled input appears able to influence command execution.",
+  ssrf:
+    "URL-fetching behavior lacks strict destination allowlisting or metadata-IP blocking.",
+  path_traversal:
+    "File-path handling lacks canonicalization and directory boundary checks.",
+  insecure_output_handling:
+    "LLM output is not safely encoded or sanitized before downstream use.",
+};
+
+function confidenceFor(
+  affectedFiles: AffectedFile[] | undefined,
+): RemediationPlan["confidence"] {
+  if (affectedFiles && affectedFiles.length > 0) return "high";
+  return "medium";
+}
+
+function categoryFixes(
+  result: AttackResult,
+): RemediationPlan["suggestedFixes"] {
+  const category = result.attack.category;
+  const commonTest = {
+    type: "test" as const,
+    title: "Add a regression test for this exact attack",
+    rationale:
+      "A red-team finding should become a repeatable safety check so the issue does not silently return.",
+    patchHint:
+      "Use the attack payload, responsePath, and expected safe behavior from this report as a fixture.",
+  };
+
+  if (
+    category === "auth_bypass" ||
+    category === "rbac_bypass" ||
+    category === "cross_tenant_access" ||
+    category === "tool_permission_escalation"
+  ) {
+    return [
+      {
+        type: "code",
+        title: "Centralize authorization before agent/tool execution",
+        rationale:
+          "Authz should be enforced before the model can invoke privileged workflows, not inferred from model output.",
+        patchHint:
+          "Validate subject, role, tenant, and tool permission in one gateway before executing any tool call.",
+      },
+      {
+        type: "policy",
+        title: "Deny privilege claims from user text",
+        rationale:
+          "Role claims embedded in prompts or request bodies should never override server-side identity.",
+      },
+      commonTest,
+    ];
+  }
+
+  if (
+    category === "data_exfiltration" ||
+    category === "sensitive_data" ||
+    category === "pii_disclosure" ||
+    category === "out_of_band_exfiltration" ||
+    category === "slow_burn_exfiltration"
+  ) {
+    return [
+      {
+        type: "guardrail",
+        title: "Add output redaction and side-channel scanning",
+        rationale:
+          "Sensitive values can appear in final text, tool outputs, traces, and streamed fragments.",
+        patchHint:
+          "Scan response text and tool_calls before returning them; redact configured secrets and synthetic canaries.",
+      },
+      {
+        type: "config",
+        title: "Replace real secrets with synthetic canaries in test environments",
+        rationale:
+          "Canaries prove leakage without putting production credentials into reports.",
+      },
+      commonTest,
+    ];
+  }
+
+  if (
+    category === "prompt_injection" ||
+    category === "indirect_prompt_injection" ||
+    category === "instruction_hierarchy_violation" ||
+    category === "prompt_template_injection"
+  ) {
+    return [
+      {
+        type: "policy",
+        title: "Harden instruction hierarchy and untrusted-content boundaries",
+        rationale:
+          "The model needs explicit rules that retrieved/user/tool text cannot override system or developer policy.",
+      },
+      {
+        type: "code",
+        title: "Wrap untrusted content with non-instructional delimiters",
+        rationale:
+          "Treat external content as data and block it from becoming executable instructions.",
+      },
+      commonTest,
+    ];
+  }
+
+  if (
+    category === "tool_misuse" ||
+    category === "tool_chain_hijack" ||
+    category === "agentic_workflow_bypass" ||
+    category === "goal_hijack"
+  ) {
+    return [
+      {
+        type: "code",
+        title: "Add per-tool authorization and workflow constraints",
+        rationale:
+          "Tool safety depends on validating both the selected tool and the full chain of actions.",
+        patchHint:
+          "Require allowlisted tools, validated arguments, and explicit approval for external sinks.",
+      },
+      {
+        type: "guardrail",
+        title: "Block unsafe source-to-sink chains",
+        rationale:
+          "Reading sensitive data and sending it externally should require separate policy checks.",
+      },
+      commonTest,
+    ];
+  }
+
+  if (
+    category === "sql_injection" ||
+    category === "shell_injection" ||
+    category === "ssrf" ||
+    category === "path_traversal"
+  ) {
+    return [
+      {
+        type: "code",
+        title: "Validate and constrain dangerous parameters",
+        rationale:
+          "Infrastructure-facing tools need canonicalization, allowlists, and parameterized execution.",
+      },
+      {
+        type: "guardrail",
+        title: "Reject high-risk tool arguments before execution",
+        rationale:
+          "The model should not be the final authority for filesystem, network, shell, or database boundaries.",
+      },
+      commonTest,
+    ];
+  }
+
+  return [
+    {
+      type: "policy",
+      title: "Tighten the category-specific judge policy and refusal behavior",
+      rationale:
+        "The response crossed the configured policy boundary or came close enough to need a regression test.",
+    },
+    commonTest,
+  ];
+}
+
+export function buildRemediationPlan(
+  result: AttackResult,
+  affectedFiles?: AffectedFile[],
+): RemediationPlan | undefined {
+  if (result.verdict !== "PASS" && result.verdict !== "PARTIAL") {
+    return undefined;
+  }
+
+  const files = (affectedFiles ?? []).map((f) =>
+    f.line ? `${f.file}:${f.line}` : f.file,
+  );
+  const rootCause =
+    CATEGORY_ROOT_CAUSES[result.attack.category] ??
+    "The target response did not satisfy the configured safety policy for this attack category.";
+
+  return {
+    rootCause,
+    confidence: confidenceFor(affectedFiles),
+    affectedFiles: files,
+    suggestedFixes: categoryFixes(result),
+    regressionTestPrompt:
+      typeof result.attack.payload.message === "string"
+        ? result.attack.payload.message
+        : JSON.stringify(result.attack.payload),
+  };
+}

--- a/lib/report-generator.ts
+++ b/lib/report-generator.ts
@@ -11,6 +11,7 @@ import type {
   ComplianceResult,
 } from "./types.js";
 import { ALL_FRAMEWORKS } from "./compliance-mappings.js";
+import { buildRemediationPlan } from "./remediation-planner.js";
 
 const SEVERITY_WEIGHTS: Record<AttackCategory, number> = {
   auth_bypass: 15,
@@ -205,15 +206,23 @@ export function generateReport(
 
   const findings = allResults
     .filter((r) => r.verdict === "PASS" || r.verdict === "PARTIAL")
-    .map((r) => ({
-      severity: r.attack.severity,
-      category: r.attack.category,
-      description: r.findings.join("; ") || r.attack.description,
-      attack: r.attack.name,
-      strategyId: r.attack.strategyId,
-      strategyName: r.attack.strategyName,
-      affectedFiles: affectedFiles?.[r.attack.category],
-    }));
+    .map((r) => {
+      const remediation = buildRemediationPlan(
+        r,
+        affectedFiles?.[r.attack.category],
+      );
+      r.remediation = remediation;
+      return {
+        severity: r.attack.severity,
+        category: r.attack.category,
+        description: r.findings.join("; ") || r.attack.description,
+        attack: r.attack.name,
+        strategyId: r.attack.strategyId,
+        strategyName: r.attack.strategyName,
+        affectedFiles: affectedFiles?.[r.attack.category],
+        remediation,
+      };
+    });
 
   const compliance = computeCompliance(allResults);
 
@@ -334,6 +343,7 @@ export function writeReport(report: Report): {
           responseTimeMs: step.responseTimeMs,
         })),
         idealResponse: r.idealResponse,
+        remediation: r.remediation,
       })),
     })),
   };
@@ -506,6 +516,14 @@ function buildMarkdown(
         lines.push(`- **Strategy:** ${f.strategyName}`);
       }
       lines.push(`- **Details:** ${f.description}`);
+      if (f.remediation) {
+        lines.push(`- **Likely Root Cause:** ${f.remediation.rootCause}`);
+        lines.push(`- **Remediation Confidence:** ${f.remediation.confidence}`);
+        lines.push(`- **Top Fixes:**`);
+        for (const fix of f.remediation.suggestedFixes.slice(0, 3)) {
+          lines.push(`  - **${fix.title}:** ${fix.rationale}`);
+        }
+      }
       if (f.affectedFiles && f.affectedFiles.length > 0) {
         lines.push(`- **Affected Source Files:**`);
         for (const af of f.affectedFiles) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -648,6 +648,19 @@ export interface IdealResponse {
   remediationHints: string[];
 }
 
+export interface RemediationPlan {
+  rootCause: string;
+  confidence: "high" | "medium" | "low";
+  affectedFiles: string[];
+  suggestedFixes: {
+    type: "code" | "config" | "policy" | "guardrail" | "test";
+    title: string;
+    rationale: string;
+    patchHint?: string;
+  }[];
+  regressionTestPrompt: string;
+}
+
 export interface AttackResult {
   attack: Attack;
   verdict: Verdict;
@@ -679,6 +692,8 @@ export interface AttackResult {
   conversation?: ConversationStep[];
   /** LLM-generated ideal response showing what the endpoint should have returned. */
   idealResponse?: IdealResponse;
+  /** Engineer-ready remediation guidance for PASS/PARTIAL findings. */
+  remediation?: RemediationPlan;
 }
 
 export interface AttackModule {
@@ -754,6 +769,7 @@ export interface Report {
     strategyId?: number;
     strategyName?: string;
     affectedFiles?: AffectedFile[];
+    remediation?: RemediationPlan;
   }[];
   staticAnalysis?: StaticAnalysisResult;
   compliance?: ComplianceResult[];

--- a/tests/report-generator.test.ts
+++ b/tests/report-generator.test.ts
@@ -138,6 +138,25 @@ describe("generateReport", () => {
     expect(report.findings).toHaveLength(2);
     expect(report.findings[0].severity).toBe("critical");
     expect(report.findings[1].description).toBe("partial leak");
+    expect(report.findings[0].remediation).toBeDefined();
+    expect(report.findings[1].remediation).toBeDefined();
+  });
+
+  it("does not attach remediation to defended or errored results", () => {
+    const rounds: RoundResult[] = [
+      {
+        round: 1,
+        results: [
+          makeResult({ verdict: "FAIL" }),
+          makeResult({ verdict: "ERROR" }),
+        ],
+      },
+    ];
+
+    const report = generateReport("http://localhost:3000/api/agent", rounds);
+    expect(report.findings).toHaveLength(0);
+    expect(report.rounds[0].results[0].remediation).toBeUndefined();
+    expect(report.rounds[0].results[1].remediation).toBeUndefined();
   });
 
   it("groups results by category", () => {


### PR DESCRIPTION
﻿## Summary

Adds deterministic, engineer-ready remediation plans to PASS and PARTIAL findings. Reports now include a likely root cause, confidence level, affected file summary, suggested fixes, and the original regression prompt so findings are easier to turn into code changes and future tests.

### Changes

1. **Remediation Planner** (`lib/remediation-planner.ts`) — New deterministic planner that maps attack categories to likely root causes and actionable fix groups. It covers auth/RBAC, data leakage, prompt injection, tool misuse, infrastructure injection classes, and a safe fallback for other categories.

2. **Remediation Type Model** (`RemediationPlan` in `lib/types.ts`) — Adds a structured remediation object with `rootCause`, `confidence`, `affectedFiles`, `suggestedFixes`, and `regressionTestPrompt`. `AttackResult` and top-level report findings can now carry this guidance.

3. **Report Generation Integration** (`lib/report-generator.ts`) — Builds remediation plans for PASS/PARTIAL findings, attaches them to the result objects, includes them in JSON reports, and renders root cause/confidence/top fixes in Markdown findings.

4. **Affected File Confidence** (`lib/remediation-planner.ts`) — Uses affected-file mappings from static analysis to raise confidence to `high`; otherwise remediation confidence defaults to `medium`.

5. **Regression Prompt Capture** (`lib/remediation-planner.ts`) — Stores the original attack prompt or payload as `regressionTestPrompt`, making it straightforward to convert a finding into a repeatable test fixture.

6. **Regression Coverage** (`tests/report-generator.test.ts`) — Verifies PASS/PARTIAL findings receive remediation and defended/errored results do not.

### Files Changed

| File | Change |
|------|--------|
| `lib/remediation-planner.ts` | **New file** — deterministic root-cause and suggested-fix planner for vulnerable results |
| `lib/types.ts` | Adds `RemediationPlan` interface and report/result remediation fields |
| `lib/report-generator.ts` | Builds remediation plans, persists them in JSON, renders them in Markdown findings |
| `tests/report-generator.test.ts` | Adds regression coverage for remediation attachment behavior |

---

## Why Remediation Plans Are Better Than Findings Alone

The existing report tells users what failed. This change adds a structured first pass at what to fix next. It does not pretend to be a full patch generator; it gives maintainers a categorized root cause, likely fix direction, affected files when known, and a regression prompt they can use to prevent recurrence.

### 1. Findings Become More Actionable

| Report Data | Before | After |
|-------------|--------|-------|
| PASS/PARTIAL finding | Severity, category, description, affected files | Same data plus root cause, confidence, top fixes, regression prompt |
| JSON report | Machine-readable result details | Machine-readable remediation object attached to vulnerable results |
| Markdown report | Human-readable finding summary | Human-readable root cause and top remediation steps |
| Static analysis link | Affected files listed separately | Affected files also feed remediation confidence |

### 2. Category-Specific Guidance Avoids Generic Advice

The planner groups fixes by the kind of failure observed:

- Auth and RBAC issues recommend centralized authorization and denial of role claims from user text.
- Data leakage issues recommend response/tool-call redaction and synthetic canaries.
- Prompt-injection issues recommend instruction hierarchy hardening and untrusted-content boundaries.
- Tool misuse issues recommend per-tool authorization and unsafe chain blocking.
- SQL, shell, SSRF, and path traversal findings recommend parameter validation, canonicalization, allowlists, and execution constraints.

### 3. Regression Tests Are Built Into the Workflow

Every remediation plan carries the original attack prompt or payload. That gives maintainers a concrete fixture to turn into a failing test before applying a fix, then a passing regression test afterward.

---

## How It Was Tested

### 1. Report Generator Regression Tests

Ran the focused report-generator suite:

```bash
npm.cmd test -- tests/report-generator.test.ts
```

Result: 13 tests passed.

### 2. TypeScript Verification

Ran the project typecheck:

```bash
npm.cmd run typecheck
```

Result: passed.

### 3. Patch Hygiene

Ran whitespace/conflict-marker verification:

```bash
git diff --check
```

Result: passed.

## Test plan

- [x] PASS findings receive remediation plans
- [x] PARTIAL findings receive remediation plans
- [x] FAIL results do not receive remediation plans
- [x] ERROR results do not receive remediation plans
- [x] Remediation plans include likely root cause, confidence, suggested fixes, affected files, and regression prompt
- [x] JSON report output includes result-level remediation data
- [x] Markdown findings render root cause, confidence, and top fixes
- [x] TypeScript compilation passes
