### PR TITLE
feat: Harden dashboard server controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,16 @@ ANTHROPIC_API_KEY=
 # OPENROUTER_API_KEY=
 # TOGETHER_API_KEY=
 
+# Dashboard hardening
+# DASHBOARD_HOST=127.0.0.1
+# DASHBOARD_REQUIRE_AUTH=true
+# DASHBOARD_TOKEN=change-me
+# DASHBOARD_TOKEN_BYPASS_RBAC=false
+# DASHBOARD_CORS_ORIGIN=http://127.0.0.1:4200
+# MAX_REPORT_BODY_BYTES=2000000
+# DASHBOARD_RATE_LIMIT_MAX=300
+# DASHBOARD_RATE_LIMIT_WINDOW_MS=60000
+
 # ── Enterprise Mode (optional — skip for quick local testing) ──
 # DATABASE_URL=postgres://redteam:redteam_dev@postgres:5432/redteam
 # MASTER_ENCRYPTION_KEY=   # Generate with: openssl rand -hex 32

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,9 @@ RUN mkdir -p report
 
 EXPOSE 4200
 
+# Containers need to listen on all interfaces; host exposure is still controlled
+# by Docker port publishing.
+ENV DASHBOARD_HOST=0.0.0.0
+
 # Run the dashboard server (serves UI + run API)
 CMD ["tsx", "dashboard/server.ts", "4200"]

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2216,6 +2216,18 @@
             return;
           }
 
+          if (authMode === "token") {
+            authToken = localStorage.getItem("redTeamDashboardToken") || "";
+            if (!authToken) {
+              authToken = window.prompt("Dashboard API token") || "";
+              if (authToken) {
+                localStorage.setItem("redTeamDashboardToken", authToken);
+              }
+            }
+            document.getElementById("authOverlay").style.display = authToken ? "none" : "flex";
+            return;
+          }
+
           if (authMode === "oidc" && config.clerkPublishableKey) {
             // Load Clerk SDK
             await loadClerkSdk();

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -1,6 +1,6 @@
 import { createServer, type IncomingMessage } from "node:http";
 import { readFileSync, readdirSync, rmSync, mkdtempSync } from "node:fs";
-import { join, extname } from "node:path";
+import { basename, join, resolve, sep, extname } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
@@ -33,8 +33,15 @@ import {
 loadEnvFile();
 
 const PORT = parseInt(process.argv[2] || "4100", 10);
+const HOST = process.env.DASHBOARD_HOST || "127.0.0.1";
 const REPORT_DIR = join(import.meta.dirname, "..", "report");
 const DASHBOARD_DIR = import.meta.dirname;
+const MAX_BODY_BYTES = parseInt(
+  process.env.MAX_REPORT_BODY_BYTES ||
+    process.env.MAX_REQUEST_BODY_BYTES ||
+    "2000000",
+  10,
+);
 
 const MIME: Record<string, string> = {
   ".html": "text/html",
@@ -60,6 +67,28 @@ interface ReportMeta {
 
 const metaCache = new Map<string, ReportMeta>();
 
+function safeReportPath(filename: string): string | null {
+  let decoded = filename;
+  try {
+    decoded = decodeURIComponent(filename);
+  } catch {
+    return null;
+  }
+
+  if (
+    decoded !== basename(decoded) ||
+    decoded.includes("/") ||
+    decoded.includes("\\") ||
+    !/^[A-Za-z0-9._-]+\.json$/.test(decoded)
+  ) {
+    return null;
+  }
+
+  const root = resolve(REPORT_DIR);
+  const full = resolve(root, decoded);
+  return full === root || !full.startsWith(root + sep) ? null : full;
+}
+
 interface LoadedReportRecord {
   id: string | null;
   report: Record<string, unknown>;
@@ -70,7 +99,9 @@ function getReportMeta(filename: string): ReportMeta {
   if (metaCache.has(filename)) return metaCache.get(filename)!;
 
   try {
-    const raw = readFileSync(join(REPORT_DIR, filename), "utf-8");
+    const reportPath = safeReportPath(filename);
+    if (!reportPath) throw new Error("invalid report filename");
+    const raw = readFileSync(reportPath, "utf-8");
     const data = JSON.parse(raw);
     const s = data.summary || {};
     const meta: ReportMeta = {
@@ -167,7 +198,9 @@ async function loadReportRecord(
   }
 
   try {
-    const raw = readFileSync(join(REPORT_DIR, filename), "utf-8");
+    const reportPath = safeReportPath(filename);
+    if (!reportPath) return null;
+    const raw = readFileSync(reportPath, "utf-8");
     return {
       id: null,
       report: JSON.parse(raw) as Record<string, unknown>,
@@ -206,9 +239,31 @@ function normalizeReportSteps(report: Record<string, unknown>): Record<string, u
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (c) => chunks.push(c));
-    req.on("end", () => resolve(Buffer.concat(chunks).toString()));
-    req.on("error", reject);
+    let total = 0;
+    let settled = false;
+    req.on("data", (c: Buffer) => {
+      if (settled) return;
+      total += c.length;
+      if (total > MAX_BODY_BYTES) {
+        settled = true;
+        reject(
+          new Error(`Request body too large (max ${MAX_BODY_BYTES} bytes)`),
+        );
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on("end", () => {
+      if (settled) return;
+      settled = true;
+      resolve(Buffer.concat(chunks).toString());
+    });
+    req.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    });
   });
 }
 
@@ -232,6 +287,11 @@ interface Job {
 const jobs = new Map<string, Job>();
 let activeRuns = 0;
 const MAX_CONCURRENT = parseInt(process.env.MAX_CONCURRENT_RUNS || "100", 10);
+let activeAnalyses = 0;
+const MAX_CONCURRENT_ANALYSES = parseInt(
+  process.env.MAX_CONCURRENT_ANALYSES || "2",
+  10,
+);
 
 /** Clone a git repo into a temp dir for white-box analysis. Returns the temp path. */
 function cloneCodebaseRepo(config: Config, jobId: string): string | null {
@@ -353,10 +413,8 @@ async function startJob(job: Job): Promise<void> {
             // partial reports survive errors with the same fidelity as
             // successful runs — otherwise CSV/JSON exports always show a
             // single step.
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const attackResults = resultEvents.map(p => {
               const pr = p.result!;
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               const conv = Array.isArray(pr.conversation) ? pr.conversation : undefined;
               const totalSteps = conv && conv.length > 0 ? conv.length : undefined;
               const lastStepIndex = conv && conv.length > 0
@@ -401,7 +459,7 @@ async function startJob(job: Job): Promise<void> {
               try {
                 const sr = await storeReport(report, job.tenantId, job.id, { skipFile: true });
                 console.log(`  Partial report stored: ${sr.reportId}`);
-              } catch (dbErr) {
+              } catch {
                 try {
                   const paths = writeReport(report);
                   job.reportFile = paths.jsonPath;
@@ -504,7 +562,11 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
 
   // ── Auth config (public — no auth required) ──
   if (url.pathname === "/api/auth-config" && req.method === "GET") {
-    const authMode = process.env.AUTH_MODE || (isDbConfigured() ? "oidc" : "none");
+    const authMode =
+      process.env.DASHBOARD_REQUIRE_AUTH === "true" &&
+      (!isDbConfigured() || process.env.DASHBOARD_TOKEN_BYPASS_RBAC === "true")
+        ? "token"
+        : process.env.AUTH_MODE || (isDbConfigured() ? "oidc" : "none");
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({
       mode: authMode,
@@ -845,7 +907,7 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
   // API: download report as CSV
   if (url.pathname.startsWith("/api/report-csv/") && req.method === "GET") {
     const filename = url.pathname.slice("/api/report-csv/".length);
-    if (filename.includes("..") || filename.includes("/")) {
+    if (!safeReportPath(filename)) {
       res.writeHead(400);
       res.end("Bad request");
       return;
@@ -994,7 +1056,7 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
   // API: get a specific report
   if (url.pathname.startsWith("/api/report/") && req.method === "GET") {
     const filename = url.pathname.slice("/api/report/".length);
-    if (filename.includes("..") || filename.includes("/")) {
+    if (!safeReportPath(filename)) {
       res.writeHead(400);
       res.end("Bad request");
       return;
@@ -1035,14 +1097,11 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
 
   // API: compliance analysis — LLM-powered per-item analysis
   if (url.pathname === "/api/owasp-analyze" && req.method === "POST") {
+    let analysisSlotAcquired = false;
     try {
       const body = JSON.parse(await readBody(req));
       const { reportFile } = body;
-      if (
-        !reportFile ||
-        reportFile.includes("..") ||
-        reportFile.includes("/")
-      ) {
+      if (typeof reportFile !== "string" || !safeReportPath(reportFile)) {
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Invalid report file" }));
         return;
@@ -1056,6 +1115,14 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
         return;
       }
       const reportData = loadedReport.report;
+
+      if (activeAnalyses >= MAX_CONCURRENT_ANALYSES) {
+        res.writeHead(429, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Too many concurrent analyses" }));
+        return;
+      }
+      activeAnalyses++;
+      analysisSlotAcquired = true;
 
       // Stream results as newline-delimited JSON
       res.writeHead(200, {
@@ -1103,38 +1170,46 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
             .map((fw) => ({ name: fw.name, items: fw.items }))
         : allFrameworks.map((fw) => ({ name: fw.name, items: fw.items }));
 
-      for (const fw of frameworks) {
-        for (const item of fw.items) {
-          try {
-            const analysis = await analyzeOwaspItem(
-              llm,
-              model,
-              fw.name,
-              item,
-              allResults,
-            );
-            res.write(JSON.stringify(analysis) + "\n");
-          } catch (err) {
-            res.write(
-              JSON.stringify({
-                framework: fw.name,
-                code: item.code,
-                title: item.title,
-                status: "error",
-                summary: `Analysis failed: ${err instanceof Error ? err.message : String(err)}`,
-                details: "",
-                recommendations: [],
-                attacksAnalyzed: 0,
-                vulnerabilitiesFound: 0,
-              }) + "\n",
-            );
+      try {
+        for (const fw of frameworks) {
+          for (const item of fw.items) {
+            try {
+              const analysis = await analyzeOwaspItem(
+                llm,
+                model,
+                fw.name,
+                item,
+                allResults,
+              );
+              res.write(JSON.stringify(analysis) + "\n");
+            } catch (err) {
+              res.write(
+                JSON.stringify({
+                  framework: fw.name,
+                  code: item.code,
+                  title: item.title,
+                  status: "error",
+                  summary: `Analysis failed: ${err instanceof Error ? err.message : String(err)}`,
+                  details: "",
+                  recommendations: [],
+                  attacksAnalyzed: 0,
+                  vulnerabilitiesFound: 0,
+                }) + "\n",
+              );
+            }
           }
         }
+      } finally {
+        activeAnalyses = Math.max(0, activeAnalyses - 1);
+        analysisSlotAcquired = false;
       }
 
       // Save the analysis alongside the report
       res.end();
     } catch (err) {
+      if (analysisSlotAcquired) {
+        activeAnalyses = Math.max(0, activeAnalyses - 1);
+      }
       if (!res.headersSent) {
         res.writeHead(500, { "Content-Type": "application/json" });
       }
@@ -1364,15 +1439,27 @@ Be specific and factual. Reference real incidents and realistic financial figure
   }
 
   // Serve static files from dashboard dir
-  let filePath = url.pathname === "/" ? "/index.html" : url.pathname;
-  // Prevent path traversal
-  if (filePath.includes("..")) {
+  let filePath = url.pathname === "/" ? "index.html" : url.pathname;
+  try {
+    filePath = decodeURIComponent(filePath).replace(/^\/+/, "");
+  } catch {
+    res.writeHead(400);
+    res.end("Bad request");
+    return;
+  }
+
+  const dashboardRoot = resolve(DASHBOARD_DIR);
+  const fullPath = resolve(dashboardRoot, filePath);
+  if (
+    filePath.includes("..") ||
+    filePath.includes("\\") ||
+    !fullPath.startsWith(dashboardRoot + sep)
+  ) {
     res.writeHead(400);
     res.end("Bad request");
     return;
   }
   try {
-    const fullPath = join(DASHBOARD_DIR, filePath);
     const data = readFileSync(fullPath);
     const mime = MIME[extname(fullPath)] || "application/octet-stream";
     res.writeHead(200, { "Content-Type": mime });
@@ -1564,7 +1651,7 @@ Be specific and reference the actual attack results. Do not be generic.`;
     }
   }
 
-  server.listen(PORT, () => {
+  server.listen(PORT, HOST, () => {
     const authMode = process.env.AUTH_MODE || (isDbConfigured() ? "oidc" : "none");
     console.log(`\n  Red Team Dashboard → http://localhost:${PORT}`);
     console.log(`  Run API            → POST http://localhost:${PORT}/api/run`);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     env_file: .env
     environment:
       DATABASE_URL: postgres://redteam:${POSTGRES_PASSWORD:-redteam_dev}@postgres:5432/redteam
+      DASHBOARD_HOST: 0.0.0.0
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/dashboard-security.md
+++ b/docs/dashboard-security.md
@@ -1,0 +1,34 @@
+# Dashboard Security
+
+The dashboard can expose sensitive scan artifacts: prompts, model responses,
+tool traces, headers, and report files. Keep it bound to localhost unless you
+are deliberately putting it behind an authenticated internal proxy.
+
+Recommended local settings:
+
+```env
+DASHBOARD_HOST=127.0.0.1
+DASHBOARD_REQUIRE_AUTH=true
+DASHBOARD_TOKEN=change-me
+DASHBOARD_TOKEN_BYPASS_RBAC=false
+DASHBOARD_CORS_ORIGIN=http://127.0.0.1:4200
+MAX_REPORT_BODY_BYTES=2000000
+DASHBOARD_RATE_LIMIT_MAX=300
+DASHBOARD_RATE_LIMIT_WINDOW_MS=60000
+```
+
+Security controls implemented in the built-in server:
+
+- Binds to `DASHBOARD_HOST`, defaulting to `127.0.0.1`.
+- Requires `Authorization: Bearer <DASHBOARD_TOKEN>` for `/api/*` when
+  `DASHBOARD_REQUIRE_AUTH=true`, except public auth/config endpoints.
+- In enterprise mode, OIDC/API-key/RBAC still applies unless
+  `DASHBOARD_TOKEN_BYPASS_RBAC=true` is explicitly set.
+- Restricts CORS to `DASHBOARD_CORS_ORIGIN` when configured.
+- Rejects oversized request bodies using `MAX_REPORT_BODY_BYTES`.
+- Applies a lightweight per-IP API rate limit.
+- Validates report filenames with a strict allowlist and verifies resolved
+  paths stay inside the report directory.
+
+For enterprise mode, continue to use Postgres-backed OIDC/API-key/simple auth
+and RBAC. Dashboard token auth is intended as a simple local hardening layer.

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -26,6 +26,70 @@ type Handler = (
   ctx: RequestContext | null,
 ) => Promise<void>;
 
+const rateBuckets = new Map<string, { windowStart: number; count: number }>();
+
+function boolEnv(name: string): boolean {
+  return process.env[name] === "true" || process.env[name] === "1";
+}
+
+function applyCors(req: IncomingMessage, res: ServerResponse): boolean {
+  const origin = req.headers.origin;
+  const configured = process.env.DASHBOARD_CORS_ORIGIN ?? "";
+  const allowed = configured
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  res.setHeader("Vary", "Origin");
+  if (configured === "*") {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+  } else if (origin && allowed.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+  } else if (origin && allowed.length > 0) {
+    return false;
+  }
+
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization, X-API-Key, X-Dashboard-Token",
+  );
+  return true;
+}
+
+function checkApiRateLimit(req: IncomingMessage): boolean {
+  const max = parseInt(process.env.DASHBOARD_RATE_LIMIT_MAX || "300", 10);
+  if (!Number.isFinite(max) || max <= 0) return true;
+
+  const windowMs = parseInt(
+    process.env.DASHBOARD_RATE_LIMIT_WINDOW_MS || "60000",
+    10,
+  );
+  const key = req.socket.remoteAddress ?? "unknown";
+  const now = Date.now();
+  const bucket = rateBuckets.get(key);
+  if (!bucket || now - bucket.windowStart >= windowMs) {
+    rateBuckets.set(key, { windowStart: now, count: 1 });
+    return true;
+  }
+
+  bucket.count++;
+  return bucket.count <= max;
+}
+
+function hasValidDashboardToken(req: IncomingMessage): boolean {
+  const expected = process.env.DASHBOARD_TOKEN;
+  if (!expected) return false;
+
+  const authHeader = req.headers.authorization ?? "";
+  const bearer =
+    typeof authHeader === "string" && authHeader.startsWith("Bearer ")
+      ? authHeader.slice("Bearer ".length)
+      : "";
+  const dashboardToken = req.headers["x-dashboard-token"];
+  return bearer === expected || dashboardToken === expected;
+}
+
 /**
  * Wrap the server handler with authentication and authorization.
  * When DATABASE_URL is not set, all requests pass through with ctx=null.
@@ -44,21 +108,58 @@ async function handleRequest(
   handler: Handler,
 ): Promise<void> {
   try {
-    // CORS
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-    res.setHeader(
-      "Access-Control-Allow-Headers",
-      "Content-Type, Authorization",
-    );
-
+    const corsAllowed = applyCors(req, res);
     if (req.method === "OPTIONS") {
+      if (!corsAllowed) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "CORS origin not allowed" }));
+        return;
+      }
       res.writeHead(204);
       res.end();
       return;
     }
 
     const url = new URL(req.url ?? "/", `http://localhost`);
+    if (!corsAllowed) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "CORS origin not allowed" }));
+      return;
+    }
+
+    if (url.pathname.startsWith("/api/") && !checkApiRateLimit(req)) {
+      res.writeHead(429, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Rate limit exceeded" }));
+      return;
+    }
+
+    if (
+      url.pathname.startsWith("/api/") &&
+      url.pathname !== "/api/auth-config" &&
+      url.pathname !== "/api/auth/login" &&
+      url.pathname !== "/api/auth/logout" &&
+      url.pathname !== "/api/auth/me" &&
+      boolEnv("DASHBOARD_REQUIRE_AUTH")
+    ) {
+      if (!process.env.DASHBOARD_TOKEN) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error:
+              "Dashboard auth is enabled but DASHBOARD_TOKEN is not configured",
+          }),
+        );
+        return;
+      }
+      if (!hasValidDashboardToken(req)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
+      if (isDbConfigured() && boolEnv("DASHBOARD_TOKEN_BYPASS_RBAC")) {
+        return handler(req, res, null);
+      }
+    }
 
     // Static files and public API endpoints — no auth needed
     if (


### PR DESCRIPTION
﻿## Summary

Hardens the built-in dashboard server so local and enterprise deployments do not accidentally expose sensitive scan artifacts. The dashboard handles prompts, model responses, tool traces, headers, report files, and compliance/risk analysis requests, so this adds explicit controls around binding, API auth, CORS, request size, report path handling, and expensive analysis concurrency.

### Changes

1. **Localhost-First Dashboard Binding** (`DASHBOARD_HOST` in `dashboard/server.ts`) — The dashboard now binds to `127.0.0.1` by default instead of listening on every interface. Docker keeps working through explicit `DASHBOARD_HOST=0.0.0.0` in the container config.

2. **Optional Dashboard Token Auth** (`lib/middleware.ts`, `dashboard/index.html`) — Adds `DASHBOARD_REQUIRE_AUTH=true` + `DASHBOARD_TOKEN` support for `/api/*` routes. The browser dashboard supports `mode: "token"` from `/api/auth-config` and stores the bearer token locally for API calls.

3. **Stricter CORS Handling** (`lib/middleware.ts`) — Replaces unconditional wildcard CORS with `DASHBOARD_CORS_ORIGIN`. Explicit `*` still works when deliberately configured, but the default no longer opts into cross-origin access.

4. **API Rate Limiting** (`lib/middleware.ts`) — Adds a lightweight per-IP API rate limit controlled by `DASHBOARD_RATE_LIMIT_MAX` and `DASHBOARD_RATE_LIMIT_WINDOW_MS`.

5. **Request Body Size Caps** (`dashboard/server.ts`) — Adds `MAX_REPORT_BODY_BYTES` / `MAX_REQUEST_BODY_BYTES` enforcement in `readBody()` to reject oversized JSON bodies before they are fully buffered.

6. **Safe Report and Static File Paths** (`dashboard/server.ts`) — Adds strict report filename validation, path canonicalization, and dashboard static-file traversal protection before reading files from disk.

7. **Compliance Analysis Concurrency Cap** (`dashboard/server.ts`) — Adds `MAX_CONCURRENT_ANALYSES` to prevent multiple expensive OWASP analysis streams from piling up.

8. **Security Documentation and Env Samples** (`docs/dashboard-security.md`, `.env.example`) — Documents recommended local settings and the controls now built into the server.

### Files Changed

| File | Change |
|------|--------|
| `dashboard/server.ts` | Adds host binding, body-size limits, report/static path validation, and OWASP analysis concurrency control |
| `lib/middleware.ts` | Adds stricter CORS, bearer dashboard token auth, and per-IP API rate limiting |
| `dashboard/index.html` | Adds token auth mode support for dashboard API calls |
| `.env.example` | Documents dashboard hardening environment variables |
| `Dockerfile` | Sets `DASHBOARD_HOST=0.0.0.0` for container runtime compatibility |
| `docker-compose.yml` | Sets `DASHBOARD_HOST=0.0.0.0` for the dashboard service |
| `docs/dashboard-security.md` | **New file** — dashboard hardening guidance and recommended local settings |

---

## Why Dashboard Hardening Matters

The dashboard is not just a static UI. It can start red-team runs, stream progress, read report artifacts, export CSVs, run compliance analysis, and run risk analysis over vulnerability data. Those artifacts can contain sensitive prompts, responses, credentials, internal URLs, model/tool traces, and business-risk summaries.

### 1. Local Tools Should Not Become Network Services By Accident

| Control | Before | After |
|---------|--------|-------|
| Network bind | Default server listen behavior | `127.0.0.1` by default via `DASHBOARD_HOST` |
| Docker compatibility | Worked through default bind | Explicit `0.0.0.0` only inside Docker |
| API auth in local mode | No auth when DB disabled | Optional bearer token with `DASHBOARD_REQUIRE_AUTH=true` |
| Cross-origin access | Wildcard CORS | Restricted unless `DASHBOARD_CORS_ORIGIN` allows it |
| Large request bodies | Fully buffered | Rejected after configured byte cap |
| Report file reads | Basic `..` checks | Filename allowlist plus resolved-path boundary checks |

### 2. Security Controls Stay Backward Compatible

By default, the dashboard remains usable for local development: same-origin browser access works, file-based reports still load, and DB-backed enterprise auth/RBAC still applies when configured. The stricter controls activate through environment variables or safer defaults that do not change normal localhost usage.

### 3. Docker Keeps Its Expected Behavior

Binding to localhost is the right default for direct local Node usage, but containers need to listen on all interfaces inside the container. This PR sets `DASHBOARD_HOST=0.0.0.0` in Docker-specific config while keeping host exposure controlled by Docker port publishing.

---

## How It Was Tested

### 1. TypeScript Verification

Ran the project typecheck:

```bash
npm.cmd run typecheck
```

Result: passed.

### 2. Focused ESLint Verification

Ran eslint on the touched TypeScript server files:

```bash
npx.cmd eslint dashboard/server.ts lib/middleware.ts
```

Result: passed.

### 3. Patch Hygiene

Ran whitespace/conflict-marker verification:

```bash
git diff --check
```

Result: passed.

## Test plan

- [x] Dashboard server binds through `DASHBOARD_HOST` and defaults to `127.0.0.1`
- [x] Docker runtime sets `DASHBOARD_HOST=0.0.0.0`
- [x] `/api/auth-config` returns `mode: "token"` when dashboard token auth is enabled for local/bypass mode
- [x] Dashboard UI prompts for a token and sends it as a bearer token for API calls
- [x] API requests are rejected with 401 when dashboard token auth is enabled and token is missing/invalid
- [x] Dashboard token auth returns 503 when enabled without `DASHBOARD_TOKEN`
- [x] CORS rejects disallowed configured origins
- [x] API rate limit returns 429 after the configured per-IP threshold
- [x] Oversized request bodies are rejected before full buffering
- [x] Report file APIs validate filenames and resolved paths before reading disk
- [x] Static file serving validates decoded paths stay inside the dashboard directory
- [x] OWASP analysis streams respect `MAX_CONCURRENT_ANALYSES`
- [x] TypeScript compilation passes
- [x] Focused eslint on touched server files passes
