### PR TITLE
feat: Show remediation plans in dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -6659,6 +6659,23 @@
         </div>`;
       }
 
+      function formatRemediationPlan(result) {
+        if (!result?.remediation) return "";
+        const rp = result.remediation;
+        const fixes = Array.isArray(rp.suggestedFixes) ? rp.suggestedFixes : [];
+        const files = Array.isArray(rp.affectedFiles) ? rp.affectedFiles : [];
+        return `<div style="margin-top:12px">
+          <div class="detail-label">Remediation Plan</div>
+          <div style="display:flex;gap:12px;flex-wrap:wrap;color:var(--text2);font-size:12px;margin-bottom:8px">
+            <span><strong>Confidence:</strong> ${esc(rp.confidence || "medium")}</span>
+            ${files.length ? `<span><strong>Files:</strong> ${files.map((f) => esc(f)).join(", ")}</span>` : ""}
+          </div>
+          <pre class="detail-pre">${esc(rp.rootCause || "")}</pre>
+          ${fixes.length ? `<ol class="ideal-response-hints">${fixes.slice(0, 4).map((fix) => `<li><strong>${esc(fix.title || fix.type || "Fix")}</strong>: ${esc(fix.rationale || "")}</li>`).join("")}</ol>` : ""}
+          ${rp.regressionTestPrompt ? `<div style="margin-top:8px"><div class="detail-label">Regression Prompt</div><pre class="detail-pre">${esc(rp.regressionTestPrompt)}</pre></div>` : ""}
+        </div>`;
+      }
+
       function toggleIdealResponse(header) {
         const body = header.nextElementSibling;
         const expand = header.querySelector("span");
@@ -6735,6 +6752,7 @@
           );
           const threatAssessmentHtml = formatThreatAssessment(result);
           const idealResponseHtml = formatIdealResponse(result);
+          const remediationPlanHtml = formatRemediationPlan(result);
 
           const tr = document.createElement("tr");
           tr.innerHTML = `
@@ -6777,6 +6795,7 @@
       </div>`
       }
       ${idealResponseHtml}
+      ${remediationPlanHtml}
       ${threatAssessmentHtml}
       ${result?.findings?.length ? `<div style="margin-top:12px"><div class="detail-label">Verdict Details</div><div>${result.findings.map((fd) => `<span class="finding-tag">${esc(fd)}</span>`).join("")}</div></div>` : ""}
       ${affectedFilesHtml ? `<div style="margin-top:12px"><div class="detail-label">Affected Files</div><div>${affectedFilesHtml}</div></div>` : ""}
@@ -7304,12 +7323,14 @@
           );
           const roundThreatAssessmentHtml = formatThreatAssessment(r);
           const roundIdealResponseHtml = formatIdealResponse(r);
+          const roundRemediationPlanHtml = formatRemediationPlan(r);
           const roundPathUid = `round-${i}`;
           const roundAttackPathHtml = buildAttackPathHtml(roundPathUid);
           detailTr.innerHTML = `<td colspan="7"><div class="detail-content">
       ${roundAttackPathHtml}
       ${r.conversation ? renderConversation(r) : renderSingleTurn(r)}
       ${roundIdealResponseHtml}
+      ${roundRemediationPlanHtml}
       ${r.findings.length ? `<div style="margin-top:12px;margin-bottom:8px"><strong>Findings:</strong><br>${r.findings.map((f) => `<span class="finding-tag">${esc(f)}</span>`).join("")}</div>` : ""}
       ${roundAffectedFilesHtml ? `<div style="margin-bottom:8px"><strong>Affected Files:</strong><br>${roundAffectedFilesHtml}</div>` : ""}
       ${roundThreatAssessmentHtml}


### PR DESCRIPTION
﻿## Summary

Adds dashboard rendering for remediation plans emitted by security reports. When a result includes `remediation`, the dashboard now shows the likely root cause, confidence, affected files, suggested fixes, and regression prompt directly in the expandable finding and round detail panels.

### Changes

1. **Remediation Plan Renderer** (`formatRemediationPlan()` in `dashboard/index.html`) — Adds a reusable dashboard formatter for structured remediation objects. It safely handles missing fields and returns an empty string for older reports with no remediation data.

2. **Findings Detail Integration** (`renderFindings()` in `dashboard/index.html`) — Shows remediation guidance below the ideal response and above the threat assessment in each expandable finding row.

3. **Round Detail Integration** (`renderRoundTable()` in `dashboard/index.html`) — Shows the same remediation block inside per-round result detail rows so users can see the fix guidance from either dashboard path.

4. **Safe Escaping for Report Data** (`dashboard/index.html`) — Escapes root causes, file names, fix titles, fix rationales, and regression prompts before rendering them into HTML.

5. **Backward Compatibility** (`dashboard/index.html`) — Older reports continue to render normally because remediation blocks are only shown when `result.remediation` exists.

### Files Changed

| File | Change |
|------|--------|
| `dashboard/index.html` | Adds remediation plan formatting and renders it in findings and round result detail panels |

---

## Why Dashboard Remediation UI Is Useful

The remediation planner makes report JSON and Markdown more actionable, but most users inspect runs through the dashboard first. This PR brings that same fix guidance into the interactive workflow without changing report generation or backend behavior.

### 1. Users Can Move From Finding To Fix Without Leaving The Dashboard

| Dashboard Area | Before | After |
|----------------|--------|-------|
| Findings detail | Prompt, response, ideal response, threat assessment, affected files | Same plus remediation root cause, confidence, top fixes, and regression prompt |
| Round detail | Per-result evidence and response body | Same plus remediation guidance when present |
| Older reports | Rendered normally | Still rendered normally; no remediation block appears |

### 2. The UI Stays Data-Driven

The dashboard does not invent remediation guidance. It only displays structured remediation data already present in the report result. That keeps the UI simple and avoids coupling it to category-specific remediation logic.

### 3. Regression Prompts Stay Close To Evidence

When a remediation plan includes `regressionTestPrompt`, the dashboard displays it next to the vulnerable response and findings. That makes it easier for maintainers to turn a red-team result into a repeatable test.

---

## How It Was Tested

### 1. TypeScript Verification

Ran the project typecheck:

```bash
npm.cmd run typecheck
```

Result: passed.

### 2. Patch Hygiene

Ran whitespace/conflict-marker verification:

```bash
git diff --check
```

Result: passed.

### 3. Compatibility Review

Reviewed the rendered code path to confirm `formatRemediationPlan()` returns an empty string when `result.remediation` is absent. This keeps existing reports compatible.

## Test plan

- [x] Finding detail rows call `formatRemediationPlan(result)`
- [x] Round detail rows call `formatRemediationPlan(r)`
- [x] Reports without `result.remediation` render exactly as before
- [x] Remediation confidence is displayed when present
- [x] Affected file strings are displayed when present
- [x] Root cause is displayed in a preformatted block
- [x] Suggested fixes render as a bounded ordered list
- [x] Regression prompt is displayed when present
- [x] All remediation text is escaped before HTML insertion
- [x] TypeScript compilation passes
