### PR TITLE
Add SSL support for Supabase and cloud Postgres providers

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -18,11 +18,19 @@ export function getPool(): pg.Pool {
     if (!process.env.DATABASE_URL) {
       throw new Error("DATABASE_URL is not set");
     }
+    const connStr = process.env.DATABASE_URL!;
+    const needsSsl =
+      connStr.includes("supabase.co") ||
+      connStr.includes("neon.tech") ||
+      connStr.includes("sslmode=require") ||
+      process.env.PG_SSL === "true";
+
     pool = new pg.Pool({
-      connectionString: process.env.DATABASE_URL,
+      connectionString: connStr,
       max: parseInt(process.env.PG_POOL_MAX || "10", 10),
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 5000,
+      ...(needsSsl ? { ssl: { rejectUnauthorized: false } } : {}),
     });
   }
   return pool;


### PR DESCRIPTION
Auto-detect Supabase/Neon URLs and enable SSL on the pg.Pool connection. Fixes silent migration failures on cloud-hosted databases.