### PR TITLE
Harden response analyzer regex handling and compliance coverage

### DIFF
--- a/lib/response-analyzer.ts
+++ b/lib/response-analyzer.ts
@@ -110,6 +110,18 @@ const BENIGN_TEMPLATE_RISK_CATEGORIES = new Set<Attack["category"]>([
   "model_fingerprinting",
 ]);
 
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function compileSensitivePattern(pattern: string): RegExp {
+  try {
+    return new RegExp(pattern, "i");
+  } catch {
+    return new RegExp(escapeRegexLiteral(pattern), "i");
+  }
+}
+
 function checkIfActualLeak(responseText: string, pattern: string): boolean {
   const lowerResponse = responseText.toLowerCase();
 
@@ -202,7 +214,7 @@ export async function analyzeResponse(
 
   // Check for sensitive patterns in the full response (but only flag as POTENTIAL leak)
   for (const pattern of config.sensitivePatterns) {
-    const regex = new RegExp(pattern, "i");
+    const regex = compileSensitivePattern(pattern);
     if (regex.test(bodyStr)) {
       // Look for context clues that this is actually a leak vs educational mention
       const isActualLeak = checkIfActualLeak(bodyStr, pattern);
@@ -222,7 +234,7 @@ export async function analyzeResponse(
     for (const tc of toolCalls) {
       const resultStr = JSON.stringify(tc.result ?? tc.output ?? "");
       for (const pattern of config.sensitivePatterns) {
-        const regex = new RegExp(pattern, "i");
+        const regex = compileSensitivePattern(pattern);
         if (regex.test(resultStr)) {
           findings.push(
             `Sensitive data in tool_calls result (side-channel): "${pattern}" in tool "${tc.tool ?? tc.function?.name ?? "unknown"}"`,
@@ -529,7 +541,7 @@ function analyzeMcpResponse(
       // Check for sensitive patterns in resource content
       const resourceContent = JSON.stringify(result);
       for (const pattern of config.sensitivePatterns) {
-        const regex = new RegExp(pattern, "i");
+        const regex = compileSensitivePattern(pattern);
         if (regex.test(resourceContent)) {
           findings.push(
             `Sensitive pattern found in MCP resource: "${pattern}"`,

--- a/tests/compliance-loader.test.ts
+++ b/tests/compliance-loader.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { loadComplianceFrameworks, listComplianceFrameworks } from "../lib/compliance-loader.js";
+
+describe("compliance loader", () => {
+  it("loads GDPR framework with populated controls", () => {
+    const frameworks = loadComplianceFrameworks();
+    const gdpr = frameworks.find((fw) => fw.id === "gdpr");
+
+    expect(gdpr).toBeDefined();
+    expect(gdpr?.name).toContain("General Data Protection Regulation");
+    expect(gdpr?.items.length).toBeGreaterThanOrEqual(10);
+    expect(gdpr?.items.some((item) => item.code === "ART-32")).toBe(true);
+    expect(gdpr?.items.some((item) => item.code === "ART-17")).toBe(true);
+  });
+
+  it("exposes GDPR in framework listing metadata", () => {
+    const frameworks = listComplianceFrameworks();
+    const gdpr = frameworks.find((fw) => fw.id === "gdpr");
+
+    expect(gdpr).toBeDefined();
+    expect(gdpr?.controlCount).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/tests/response-analyzer.test.ts
+++ b/tests/response-analyzer.test.ts
@@ -80,6 +80,29 @@ describe("analyzeResponse", () => {
       expect(result.verdict).toBe("ERROR");
     });
 
+    it("treats invalid sensitive regex patterns as literal strings", async () => {
+      const result = await analyzeResponse(
+        makeConfig({
+          sensitivePatterns: ["+1-555-"],
+          attackConfig: {
+            ...makeConfig().attackConfig,
+            enableLlmGeneration: false,
+          },
+        }),
+        makeAttack(),
+        200,
+        { response: "Please call +1-555-0100 for claim follow-up." },
+        100,
+      );
+
+      expect(result.verdict).toBe("FAIL");
+      expect(result.findings).toEqual(
+        expect.arrayContaining([
+          'Potential sensitive mention (needs LLM review): "+1-555-"',
+        ]),
+      );
+    });
+
     it("returns PASS when sensitive pattern is found in response", async () => {
       const body = { response: "Here is the key: sk-proj-abc123" };
       const result = await analyzeResponse(


### PR DESCRIPTION
## What We Changed

- Improved response analysis reliability by safely handling invalid sensitive-pattern regex values.
- Added fallback behavior to treat invalid patterns as literals instead of throwing at runtime.
- Added/updated tests to validate:
  - invalid pattern handling in response analysis
  - compliance framework loading metadata and controls

## Why We Changed It

- Invalid regex-like sensitive patterns can cause runtime failures during analysis.
- We need analysis to fail safe and continue producing actionable verdicts.
- Compliance loader behavior should be explicitly tested to prevent silent regressions.

## How It Improves the Application

- Prevents runtime regex crashes in response analysis paths.
- Improves robustness and predictability of verdict generation.
- Strengthens confidence in compliance/report readiness through targeted tests.

## Test Plan

- `npm run typecheck`
- `npm test -- tests/response-analyzer.test.ts tests/compliance-loader.test.ts`