### PR TITLE
Wire up VotalAI logo path in docs _config.yml

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,6 +5,9 @@ baseurl: /wb-red-team
 
 remote_theme: just-the-docs/just-the-docs
 
+# Sidebar logo
+logo: "/assets/votalai-logo.png"
+
 plugins:
   - jekyll-remote-theme
   - jekyll-seo-tag


### PR DESCRIPTION
## Summary

Wires up the VotalAI logo in the docs site sidebar by adding a `logo:` declaration to `docs/_config.yml`. just-the-docs will render the logo in the top-left of the sidebar once the PNG file is committed at the referenced path.

## Files

- `docs/_config.yml` — added `logo: "/assets/votalai-logo.png"`

## Follow-up needed

The PNG file itself still needs to be added at `docs/assets/votalai-logo.png`. Until that file lands, the logo slot in the sidebar will be empty — nothing else breaks.

https://claude.ai/code/session_015Ac8b7ZF5CM1DMuv93rbF2

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ac8b7ZF5CM1DMuv93rbF2)_