### PR TITLE
Configure custom domain docs.cart.votal.ai for docs site

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.cart.votal.ai

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: Red-Team AI Docs
 description: White-box red teaming for agentic AI apps. Reads your code, finds bugs specific to your stack.
-url: https://sundi133.github.io
-baseurl: /wb-red-team
+url: https://docs.cart.votal.ai
+baseurl: ""
 
 remote_theme: just-the-docs/just-the-docs
 


### PR DESCRIPTION
## Summary

Configures the docs site to serve at the custom domain **`docs.cart.votal.ai`** instead of `https://sundi133.github.io/wb-red-team/`.

## Files

- `docs/CNAME` (new) — tells GitHub Pages to bind the site to `docs.cart.votal.ai`
- `docs/_config.yml` — `url` updated to the custom domain; `baseurl` cleared (custom domain serves at root, not under `/wb-red-team`)

## Required out-of-band steps

1. **GoDaddy DNS (votal.ai zone):** add `CNAME docs.cart -> sundi133.github.io`, TTL 600
2. **Repo Settings → Pages → Custom domain:** enter `docs.cart.votal.ai`, save, wait for DNS check, then tick **Enforce HTTPS** once the cert provisions

## Verify after deploy

```bash
host docs.cart.votal.ai
curl -I https://docs.cart.votal.ai/
curl -I https://sundi133.github.io/wb-red-team/   # should 301 to new domain
```

## Note

Internal links in the pages already use `{{ site.baseurl }}/...`. With `baseurl=""` these resolve to `/quick-start/`, `/white-box/`, etc., which is correct under the custom domain.

https://claude.ai/code/session_015Ac8b7ZF5CM1DMuv93rbF2

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ac8b7ZF5CM1DMuv93rbF2)_