### PR TITLE
Add DB persistence for guardrail reports and OC Postgres manifests

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -32,6 +32,13 @@ import {
   getSimpleSessionUser,
   loginSimpleUser,
 } from "../lib/auth-simple.js";
+import {
+  storeGuardrailReport,
+  getGuardrailReport,
+  listGuardrailReports,
+  extractGuardrailSummary,
+  type GuardrailReportMeta,
+} from "../lib/guardrail-store.js";
 
 loadEnvFile();
 
@@ -1033,44 +1040,48 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
 
   // API: list litellm guardrails reports
   if (url.pathname === "/api/litellm-reports" && req.method === "GET") {
+    // Collect from DB
+    let dbMetas: GuardrailReportMeta[] = [];
+    if (isDbConfigured() && ctx?.tenantId) {
+      try {
+        dbMetas = await listGuardrailReports(ctx.tenantId);
+      } catch (dbErr) {
+        console.error("  [guardrails] DB list failed, falling back to files:", dbErr);
+      }
+    }
+    // Collect from files (for reports not yet in DB)
+    let fileMetas: GuardrailReportMeta[] = [];
     try {
+      const dbFilenames = new Set(dbMetas.map((m) => m.filename));
       const files = readdirSync(LITELLM_REPORT_DIR)
-        .filter((f) => f.endsWith(".json"))
+        .filter((f) => f.endsWith(".json") && !dbFilenames.has(f))
         .sort()
         .reverse();
-      const metas = files.map((f) => {
+      fileMetas = files.map((f) => {
         try {
           const raw = JSON.parse(readFileSync(join(LITELLM_REPORT_DIR, f), "utf-8"));
-          const results = raw.results || [];
-          const goodTotal = results.filter((r: any) => r.without_guardrails?.category === "good").length;
-          const badTotal = results.filter((r: any) => r.without_guardrails?.category === "bad").length;
-          const blocked = results.filter((r: any) => {
-            const g = r.with_guardrails;
-            if (!g || g.category !== "bad") return false;
-            if (g.verdict) return g.verdict === "guardrail_blocked" || g.verdict === "safe_refusal_or_redirect";
-            return g.status_code === 400 || g.status_code === 403 ||
-              (g.response_text || "").toLowerCase().includes("blocked by votal guardrails");
-          }).length;
+          const summary = extractGuardrailSummary(raw);
           return {
             filename: f,
             created_at: raw.created_at || "",
-            model: raw.model || "",
-            guardrails: raw.guardrails || [],
-            goodTotal,
-            badTotal,
-            blocked,
-            total: results.length,
+            model: summary.model,
+            guardrails: summary.guardrails,
+            goodTotal: summary.goodTotal,
+            badTotal: summary.badTotal,
+            blocked: summary.blocked,
+            total: summary.total,
           };
         } catch {
           return { filename: f, created_at: "", model: "", guardrails: [], goodTotal: 0, badTotal: 0, blocked: 0, total: 0 };
         }
       });
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(metas));
     } catch {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end("[]");
+      // No report directory — that's fine
     }
+    // Merge: DB reports first, then file-only reports
+    const merged = [...dbMetas, ...fileMetas];
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(merged));
     return;
   }
 
@@ -1082,6 +1093,20 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
       res.end("Bad request");
       return;
     }
+    // Try DB first
+    if (isDbConfigured() && ctx?.tenantId) {
+      try {
+        const json = await getGuardrailReport(filename, ctx.tenantId);
+        if (json) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(json);
+          return;
+        }
+      } catch (dbErr) {
+        console.error("  [guardrails] DB get failed, falling back to file:", dbErr);
+      }
+    }
+    // File fallback
     try {
       const raw = readFileSync(join(LITELLM_REPORT_DIR, filename), "utf-8");
       res.writeHead(200, { "Content-Type": "application/json" });
@@ -1103,12 +1128,21 @@ const server = createServer(withMiddleware(async (req, res, ctx) => {
         res.end(JSON.stringify({ error: "Invalid report: missing results array" }));
         return;
       }
+      // Always write to disk as fallback
       if (!existsSync(LITELLM_REPORT_DIR)) {
         mkdirSync(LITELLM_REPORT_DIR, { recursive: true });
       }
       const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19) + "Z";
       const filename = `litellm-guardrails-${ts}.json`;
       writeFileSync(join(LITELLM_REPORT_DIR, filename), JSON.stringify(parsed, null, 2));
+      // Also store in DB if available
+      if (isDbConfigured() && ctx?.tenantId) {
+        try {
+          await storeGuardrailReport(body, ctx.tenantId, filename);
+        } catch (dbErr) {
+          console.error("  [guardrails] DB store failed (file was saved):", dbErr);
+        }
+      }
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ filename, message: "Report uploaded" }));
     } catch (err) {

--- a/lib/guardrail-store.ts
+++ b/lib/guardrail-store.ts
@@ -1,0 +1,196 @@
+/**
+ * Guardrail report storage — dual-write to Postgres (encrypted) and disk.
+ * Falls back to file-only mode when DATABASE_URL is not set.
+ */
+
+import { query } from "./db.js";
+import { encryptWithTenantKey, decryptWithTenantKey } from "./encryption.js";
+
+/** Convert filename-style timestamps like "2026-05-12T14-26-27Z" to valid ISO "2026-05-12T14:26:27Z". */
+function normalizeTimestamp(ts: string | undefined): string | undefined {
+  if (!ts) return undefined;
+  // Match pattern: date T HH-MM-SS and replace dashes in time with colons
+  const fixed = ts.replace(/T(\d{2})-(\d{2})-(\d{2})/, "T$1:$2:$3");
+  const d = new Date(fixed);
+  return isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+export interface GuardrailReportMeta {
+  filename: string;
+  created_at: string;
+  model: string;
+  guardrails: string[];
+  goodTotal: number;
+  badTotal: number;
+  blocked: number;
+  total: number;
+}
+
+/** Extract summary fields from a parsed guardrail report. */
+export function extractGuardrailSummary(parsed: any): {
+  model: string;
+  guardrails: string[];
+  goodTotal: number;
+  badTotal: number;
+  blocked: number;
+  total: number;
+  reportTs: string;
+} {
+  const results = parsed.results || [];
+  const goodTotal = results.filter(
+    (r: any) => r.without_guardrails?.category === "good",
+  ).length;
+  const badTotal = results.filter(
+    (r: any) => r.without_guardrails?.category === "bad",
+  ).length;
+  const blocked = results.filter((r: any) => {
+    const g = r.with_guardrails;
+    if (!g || g.category !== "bad") return false;
+    if (g.verdict)
+      return (
+        g.verdict === "guardrail_blocked" ||
+        g.verdict === "safe_refusal_or_redirect"
+      );
+    return (
+      g.status_code === 400 ||
+      g.status_code === 403 ||
+      (g.response_text || "").toLowerCase().includes("blocked by votal guardrails")
+    );
+  }).length;
+
+  return {
+    model: parsed.model || "",
+    guardrails: parsed.guardrails || [],
+    goodTotal,
+    badTotal,
+    blocked,
+    total: results.length,
+    reportTs: normalizeTimestamp(parsed.created_at) || new Date().toISOString(),
+  };
+}
+
+/**
+ * Store a guardrail report: encrypt and write to Postgres.
+ */
+export async function storeGuardrailReport(
+  reportJson: string,
+  tenantId: string,
+  filename: string,
+): Promise<{ reportId: string }> {
+  const tenantResult = await query<{ encryption_key_enc: string }>(
+    "SELECT encryption_key_enc FROM tenants WHERE id = $1",
+    [tenantId],
+  );
+  if (tenantResult.rows.length === 0) {
+    throw new Error(`Tenant not found: ${tenantId}`);
+  }
+
+  const tenantKeyEnc = tenantResult.rows[0].encryption_key_enc;
+  const { ciphertext, iv, authTag } = encryptWithTenantKey(
+    reportJson,
+    tenantKeyEnc,
+  );
+
+  const parsed = JSON.parse(reportJson);
+  const summary = extractGuardrailSummary(parsed);
+
+  const result = await query<{ id: string }>(
+    `INSERT INTO guardrail_reports (
+      tenant_id, filename, report_enc, iv, auth_tag,
+      model, guardrails, good_total, bad_total, blocked, total, report_ts
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    ON CONFLICT (tenant_id, filename) DO UPDATE SET
+      report_enc = EXCLUDED.report_enc,
+      iv = EXCLUDED.iv,
+      auth_tag = EXCLUDED.auth_tag,
+      model = EXCLUDED.model,
+      guardrails = EXCLUDED.guardrails,
+      good_total = EXCLUDED.good_total,
+      bad_total = EXCLUDED.bad_total,
+      blocked = EXCLUDED.blocked,
+      total = EXCLUDED.total,
+      report_ts = EXCLUDED.report_ts
+    RETURNING id`,
+    [
+      tenantId,
+      filename,
+      ciphertext,
+      iv,
+      authTag,
+      summary.model,
+      JSON.stringify(summary.guardrails),
+      summary.goodTotal,
+      summary.badTotal,
+      summary.blocked,
+      summary.total,
+      summary.reportTs,
+    ],
+  );
+
+  return { reportId: result.rows[0].id };
+}
+
+/**
+ * Retrieve and decrypt a guardrail report from Postgres.
+ */
+export async function getGuardrailReport(
+  filename: string,
+  tenantId: string,
+): Promise<string | null> {
+  const result = await query<{
+    report_enc: Buffer;
+    iv: Buffer;
+    auth_tag: Buffer;
+  }>(
+    `SELECT report_enc, iv, auth_tag
+     FROM guardrail_reports WHERE filename = $1 AND tenant_id = $2`,
+    [filename, tenantId],
+  );
+
+  if (result.rows.length === 0) return null;
+
+  const row = result.rows[0];
+  const tenantResult = await query<{ encryption_key_enc: string }>(
+    "SELECT encryption_key_enc FROM tenants WHERE id = $1",
+    [tenantId],
+  );
+  const tenantKeyEnc = tenantResult.rows[0].encryption_key_enc;
+
+  return decryptWithTenantKey(row.report_enc, row.iv, row.auth_tag, tenantKeyEnc);
+}
+
+/**
+ * List guardrail reports for a tenant (plaintext summary columns, no decryption).
+ */
+export async function listGuardrailReports(
+  tenantId: string,
+): Promise<GuardrailReportMeta[]> {
+  const result = await query<{
+    filename: string;
+    report_ts: string;
+    model: string;
+    guardrails: string[];
+    good_total: number;
+    bad_total: number;
+    blocked: number;
+    total: number;
+  }>(
+    `SELECT filename, report_ts, model, guardrails,
+            good_total, bad_total, blocked, total
+     FROM guardrail_reports
+     WHERE tenant_id = $1
+     ORDER BY report_ts DESC`,
+    [tenantId],
+  );
+
+  return result.rows.map((r) => ({
+    filename: r.filename,
+    created_at: r.report_ts,
+    model: r.model || "",
+    guardrails: r.guardrails || [],
+    goodTotal: r.good_total,
+    badTotal: r.bad_total,
+    blocked: r.blocked,
+    total: r.total,
+  }));
+}

--- a/lib/migrations/002-guardrail-reports.sql
+++ b/lib/migrations/002-guardrail-reports.sql
@@ -1,0 +1,23 @@
+-- Migration 002: Guardrail reports persistence
+-- Stores LiteLLM guardrail evaluation reports in the database
+
+CREATE TABLE IF NOT EXISTS guardrail_reports (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     UUID NOT NULL REFERENCES tenants(id),
+  filename      TEXT NOT NULL,
+  report_enc    BYTEA NOT NULL,
+  iv            BYTEA NOT NULL,
+  auth_tag      BYTEA NOT NULL,
+  model         TEXT,
+  guardrails    JSONB,
+  good_total    INTEGER NOT NULL DEFAULT 0,
+  bad_total     INTEGER NOT NULL DEFAULT 0,
+  blocked       INTEGER NOT NULL DEFAULT 0,
+  total         INTEGER NOT NULL DEFAULT 0,
+  report_ts     TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_guardrail_reports_tenant ON guardrail_reports(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_guardrail_reports_tenant_ts ON guardrail_reports(tenant_id, report_ts DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_guardrail_reports_filename ON guardrail_reports(tenant_id, filename);

--- a/openshift/deploy-no-db.example.yaml
+++ b/openshift/deploy-no-db.example.yaml
@@ -1,6 +1,9 @@
 # Secret: API keys and auth config (no DB)
 # NOTE: Replace these placeholder values with freshly-rotated keys.
 # The previous keys shared in chat must be revoked.
+#
+# WARNING: Without a database, guardrail reports and run history are lost
+# on pod restart. For persistent storage, use deploy-with-db.example.yaml instead.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/openshift/deploy-with-db.example.yaml
+++ b/openshift/deploy-with-db.example.yaml
@@ -1,0 +1,299 @@
+# =============================================================================
+# Red Team Dashboard — OpenShift deployment WITH Postgres
+# =============================================================================
+# This adds Postgres to the no-db deployment so guardrail reports, red-team
+# reports, audit logs, and compliance analyses persist across pod restarts.
+#
+# To deploy:
+#   oc apply -f openshift/deploy-with-db.example.yaml
+#
+# To upgrade from no-db:
+#   1. Generate encryption key:  openssl rand -hex 32
+#   2. Update the Secret below with the key and a strong DB password
+#   3. oc apply -f openshift/deploy-with-db.example.yaml
+#   4. The migration runs automatically on dashboard startup
+# =============================================================================
+
+---
+# Secret: API keys, DB credentials, encryption key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: red-team-secrets
+  labels:
+    app.kubernetes.io/part-of: red-team-ai
+type: Opaque
+stringData:
+  ANTHROPIC_API_KEY: ""                    # REQUIRED
+  OPENAI_API_KEY: ""                       # optional
+  POSTGRES_PASSWORD: "CHANGE-ME-STRONG"    # REQUIRED: strong password
+  DATABASE_URL: "postgres://redteam:CHANGE-ME-STRONG@postgres:5432/redteam"
+  MASTER_ENCRYPTION_KEY: ""                # REQUIRED: openssl rand -hex 32
+  SIMPLE_AUTH_SESSION_SECRET: ""           # REQUIRED: openssl rand -hex 32
+  SIMPLE_AUTH_PASSWORD: ""                 # REQUIRED: dashboard login password
+
+---
+# PVC: Postgres data
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  labels:
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 5Gi
+
+---
+# PVC: Red-team reports (file fallback)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: red-team-reports
+  labels:
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 2Gi
+
+---
+# PVC: Guardrails reports (file fallback)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: red-team-guardrail-reports
+  labels:
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 2Gi
+
+---
+# ── Postgres Deployment ──
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: redteam
+            - name: POSTGRES_USER
+              value: redteam
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: red-team-secrets
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "redteam"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "redteam"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: pgdata
+          persistentVolumeClaim:
+            claimName: postgres-data
+
+---
+# Postgres Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+
+---
+# ── Red Team Dashboard ──
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: red-team-dashboard
+  labels:
+    app: red-team-dashboard
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: red-team-dashboard
+  template:
+    metadata:
+      labels:
+        app: red-team-dashboard
+    spec:
+      containers:
+        - name: dashboard
+          image: docker.io/sundi133/wb-red-team:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 4200
+              name: http
+          env:
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: red-team-secrets
+                  key: ANTHROPIC_API_KEY
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: red-team-secrets
+                  key: OPENAI_API_KEY
+                  optional: true
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: red-team-secrets
+                  key: DATABASE_URL
+            - name: MASTER_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: red-team-secrets
+                  key: MASTER_ENCRYPTION_KEY
+            - name: AUTH_MODE
+              value: "simple"
+            - name: SIMPLE_AUTH_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: red-team-secrets
+                  key: SIMPLE_AUTH_SESSION_SECRET
+            - name: SIMPLE_AUTH_SESSION_TTL_HOURS
+              value: "12"
+            - name: SIMPLE_AUTH_USERNAME
+              value: "admin"
+            - name: SIMPLE_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: red-team-secrets
+                  key: SIMPLE_AUTH_PASSWORD
+            - name: SIMPLE_AUTH_ROLE
+              value: "admin"
+            - name: SIMPLE_AUTH_NAME
+              value: "Admin User"
+            # Add proxy env vars if behind corporate proxy:
+            # - name: HTTP_PROXY
+            #   value: "http://your-proxy:8080"
+            # - name: HTTPS_PROXY
+            #   value: "http://your-proxy:8080"
+            - name: NO_PROXY
+              value: "localhost,127.0.0.1,.svc,.cluster.local,postgres"
+          volumeMounts:
+            - name: reports
+              mountPath: /app/report
+            - name: guardrail-reports
+              mountPath: /app/reports
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 4200
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 4200
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+      volumes:
+        - name: reports
+          persistentVolumeClaim:
+            claimName: red-team-reports
+        - name: guardrail-reports
+          persistentVolumeClaim:
+            claimName: red-team-guardrail-reports
+
+---
+# Dashboard Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: red-team-dashboard
+  labels:
+    app: red-team-dashboard
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  selector:
+    app: red-team-dashboard
+  ports:
+    - port: 4200
+      targetPort: 4200
+      name: http
+
+---
+# OpenShift Route (TLS edge termination)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: red-team-dashboard
+  labels:
+    app: red-team-dashboard
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  to:
+    kind: Service
+    name: red-team-dashboard
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/openshift/postgres.yaml
+++ b/openshift/postgres.yaml
@@ -1,0 +1,120 @@
+# =============================================================================
+# Standalone Postgres for Red Team Dashboard — OpenShift
+# =============================================================================
+# Deploy this separately before the dashboard if you want to manage
+# Postgres independently (e.g., shared across environments).
+#
+# Usage:
+#   oc apply -f openshift/postgres.yaml
+#   oc wait --for=condition=ready pod -l app=postgres --timeout=60s
+#
+# Then deploy the dashboard with DATABASE_URL pointing to this service:
+#   postgres://redteam:<password>@postgres:5432/redteam
+# =============================================================================
+
+---
+# Secret: Postgres credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secrets
+  labels:
+    app: postgres
+    app.kubernetes.io/part-of: red-team-ai
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: "CHANGE-ME-STRONG"    # REQUIRED: change this
+
+---
+# PVC: Postgres data
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  labels:
+    app: postgres
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 5Gi
+
+---
+# Postgres Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: redteam
+            - name: POSTGRES_USER
+              value: redteam
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secrets
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "redteam"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "redteam"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: pgdata
+          persistentVolumeClaim:
+            claimName: postgres-data
+
+---
+# Postgres Service (accessible as "postgres:5432" within the namespace)
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432


### PR DESCRIPTION
- New guardrail_reports table (migration 002) with encrypted storage
- New lib/guardrail-store.ts: store, get, list with tenant encryption
- Dashboard routes: dual-write (DB + file), merge results from both
- Fix timestamp normalization for filename-style dates
- Add openshift/postgres.yaml for standalone Postgres deployment
- Add openshift/deploy-with-db.example.yaml for full DB setup