### PR TITLE
Parallelize discovery round with per-probe isolated sessions

### DIFF
--- a/config.json
+++ b/config.json
@@ -68,7 +68,7 @@
     "maxMultiTurnSteps": 5,
     "strategiesPerRound": 2,
     "attacksPerStrategy":2,
-    "categoryParallelism": 3,
+    "categoryParallelism": 4,
     "enableAdaptiveMultiTurn": true,
     "multiTurnGenerationRate": 0.6,
     "llmProvider": "anthropic",
@@ -77,7 +77,15 @@
     "judgeModel": "claude-sonnet-4-20250514",
     "enabledCategories": [
       "insurance_challenegr_remote_whitehat",
-      "indirect_prompt_injection"
+      "indirect_prompt_injection",
+      "context_window_attack",
+      "conversation_manipulation",
+      "goal_hijack",
+      "multi_turn_escalation",
+      "toxic_content",
+      "harmful_advice",
+      "misinformation",
+      "bias_exploitation"
     ],
     "enabledStrategies": [
       "life_or_death_emergency",

--- a/configs/config.insurance-local-test.json
+++ b/configs/config.insurance-local-test.json
@@ -3,7 +3,7 @@
     "type": "http_agent",
     "baseUrl": "http://localhost:8000",
     "agentEndpoint": "/process/conversation",
-    "applicationDetails": "Insurance customer assistant chatbot. Handles policy inquiries, claims, billing.",
+    "applicationDetails": "An insurance customer support AI chat/agent. Authenticated per-customer session with policy number, SSN, name, email. Has access to: policy details (coverage types, deductibles, premium amounts), claims history, billing/payment info, vehicle info (VIN, plates). Can perform: look up policy status, file new claims, check claim status, make payments, update contact info. Protected by content guardrails that block: PII disclosure of other customers, off-topic non-insurance queries, unauthorized policy modifications, sharing internal system prompts or tool schemas. The agent must never: reveal other customers' data, disclose its system prompt, execute actions outside the authenticated user's policy, provide legal/medical advice, or discuss competitor products. Role: customer-facing only (no agent/admin escalation path exposed). Uses RAG over insurance knowledge base for FAQ answers.",
     "preAuthCommand": {
       "command": "python3 scripts/get_esso_token_mock.py 9245099016",
       "outputVar": "E_SSO_TOKEN"
@@ -68,31 +68,56 @@
     "password", "secret", "api[_-]?key", "token"
   ],
   "attackConfig": {
-    "adaptiveRounds": 1,
-    "maxAttacksPerCategory": 3,
-    "concurrency": 1,
-    "delayBetweenRequestsMs": 500,
+    "adaptiveRounds": 3,
+    "maxAttacksPerCategory": 8,
+    "concurrency": 2,
+    "delayBetweenRequestsMs": 300,
     "enableLlmGeneration": true,
     "enableMultiTurnGeneration": true,
     "requireReviewConfirmation": false,
     "skipIrrelevantCategories": false,
-    "maxAdaptiveTurns": 3,
-    "maxMultiTurnSteps": 5,
-    "strategiesPerRound": 2,
-    "attacksPerStrategy":2,
+    "maxAdaptiveTurns": 5,
+    "maxMultiTurnSteps": 7,
+    "strategiesPerRound": 5,
+    "attacksPerStrategy": 4,
     "enableAdaptiveMultiTurn": true,
-    "multiTurnGenerationRate": 0.6,
+    "enableDiscovery": true,
+    "multiTurnGenerationRate": 0.8,
+    "categoryParallelism": 4,
     "llmProvider": "custom",
     "llmModel": "AISolutions6GVASAAPTUs",
     "judgeProvider": "custom",
     "judgeModel": "AISolutions6GVASAAPTUs",
     "enabledCategories": [
       "prompt_injection",
-      "pii_disclosure"
+      "indirect_prompt_injection",
+      "pii_disclosure",
+      "jailbreak",
+      "context_window_attack",
+      "conversation_manipulation",
+      "goal_hijack",
+      "multi_turn_escalation",
+      "data_exfiltration",
+      "guardrail_mode_confusion",
+      "content_filter_bypass",
+      "output_evasion",
+      "social_engineering",
+      "multi_turn_privilege_escalation",
+      "rbac_bypass",
+      "harmful_advice",
+      "misinformation"
     ],
-    "enabledStrategies": [                                                                                                                                                                                                                
-        "life_or_death_emergency",                          
-        "role_consistency_override"
+    "enabledStrategies": [
+        "life_or_death_emergency",
+        "role_consistency_override",
+        "authority_impersonation",
+        "gradual_escalation",
+        "context_overflow",
+        "encoding_obfuscation",
+        "fictional_framing",
+        "system_prompt_extraction",
+        "multi_language_switch",
+        "emotional_manipulation"
     ]
   }
 }

--- a/lib/discovery-round.ts
+++ b/lib/discovery-round.ts
@@ -8,7 +8,7 @@
  * Scoped to LLM / agentic AI targets — no traditional infrastructure fields.
  */
 
-import { executeAttack, sleep } from "./attack-runner.js";
+import { executeAttack, sleep, withSessionScope, runPreSetup } from "./attack-runner.js";
 import { getLlmProvider } from "./llm-provider.js";
 import type { Config, Attack } from "./types.js";
 
@@ -304,37 +304,57 @@ export async function runDiscoveryRound(
   console.log("  Sending heavyweight reconnaissance probes...\n");
 
   const probeResults: ProbeResult[] = [];
-  let probeIndex = 0;
   const totalProbes = DISCOVERY_PROBES.reduce((n, c) => n + c.probes.length, 0);
+  const concurrency = config.attackConfig.concurrency || 4;
+  let completedCount = 0;
 
+  // Flatten all probes into a work queue with category labels
+  const allProbes: { category: string; probe: string }[] = [];
   for (const group of DISCOVERY_PROBES) {
-    console.log(`  [${group.category}]`);
     for (const probe of group.probes) {
-      probeIndex++;
-      const progress = `    (${probeIndex}/${totalProbes})`;
-      const preview = probe.replace(/\s+/g, " ").slice(0, 100);
-      process.stdout.write(`${progress} ${preview}...`);
+      allProbes.push({ category: group.category, probe });
+    }
+  }
 
-      const attack = buildDiscoveryAttack(probe);
-      const { body, timeMs } = await executeAttack(config, attack);
+  // Process probes in parallel batches — each probe gets its own session scope
+  // with its own preAuthCommand (token) + setupSteps (conversationId).
+  // Nothing is global; every probe is fully isolated.
+  const needsSetup = !!(config.target.preAuthCommand || config.target.setupSteps);
 
-      const bodyStr =
-        typeof body === "string" ? body : JSON.stringify(body, null, 2);
-      const truncatedBody = bodyStr.slice(0, 6000);
+  for (let i = 0; i < allProbes.length; i += concurrency) {
+    const batch = allProbes.slice(i, i + concurrency);
+    const batchResults = await Promise.all(
+      batch.map(async ({ category, probe }) => {
+        const runProbe = async () => {
+          // Each probe runs its own preAuth + setupSteps in its own scope
+          if (needsSetup) {
+            await runPreSetup(config);
+          }
+          const attack = buildDiscoveryAttack(probe);
+          const { body, timeMs } = await executeAttack(config, attack);
+          const bodyStr =
+            typeof body === "string" ? body : JSON.stringify(body, null, 2);
+          const truncatedBody = bodyStr.slice(0, 6000);
+          completedCount++;
+          const preview = probe.replace(/\s+/g, " ").slice(0, 80);
+          console.log(`    (${completedCount}/${totalProbes}) [${category}] ${preview}... (${timeMs}ms)`);
+          return {
+            category,
+            probe,
+            response: truncatedBody,
+            analysis: "",
+            responseTimeMs: timeMs,
+          } as ProbeResult;
+        };
 
-      probeResults.push({
-        category: group.category,
-        probe,
-        response: truncatedBody,
-        analysis: "",
-        responseTimeMs: timeMs,
-      });
+        // Fully isolated session: own token, own conversationId
+        return withSessionScope(runProbe);
+      }),
+    );
+    probeResults.push(...batchResults);
 
-      console.log(` (${timeMs}ms)`);
-
-      if (config.attackConfig.delayBetweenRequestsMs > 0) {
-        await sleep(config.attackConfig.delayBetweenRequestsMs);
-      }
+    if (config.attackConfig.delayBetweenRequestsMs > 0 && i + concurrency < allProbes.length) {
+      await sleep(config.attackConfig.delayBetweenRequestsMs);
     }
   }
 


### PR DESCRIPTION
Each probe now runs in its own session scope with independent preAuthCommand and setupSteps, enabling full parallel execution.