### PR TITLE
Fix 8 VAPT security vulnerabilities from pentest report

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -60,6 +60,43 @@ const LITELLM_REPORT_DIR = join(
 );
 const DASHBOARD_DIR = import.meta.dirname;
 
+// ── Login rate limiter ──
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+const loginAttempts = new Map<string, RateLimitEntry>();
+const LOGIN_RATE_LIMIT = parseInt(process.env.LOGIN_RATE_LIMIT || "5", 10);
+const LOGIN_RATE_WINDOW_MS = parseInt(
+  process.env.LOGIN_RATE_WINDOW_MS || "900000",
+  10,
+); // 15 min
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of loginAttempts) {
+    if (entry.resetAt <= now) loginAttempts.delete(key);
+  }
+}, 600_000).unref();
+
+function checkLoginRateLimit(ip: string): {
+  allowed: boolean;
+  retryAfterSec: number;
+} {
+  const now = Date.now();
+  const entry = loginAttempts.get(ip);
+  if (!entry || entry.resetAt <= now) {
+    loginAttempts.set(ip, { count: 1, resetAt: now + LOGIN_RATE_WINDOW_MS });
+    return { allowed: true, retryAfterSec: 0 };
+  }
+  entry.count++;
+  if (entry.count > LOGIN_RATE_LIMIT) {
+    const retryAfterSec = Math.ceil((entry.resetAt - now) / 1000);
+    return { allowed: false, retryAfterSec };
+  }
+  return { allowed: true, retryAfterSec: 0 };
+}
+
 const MIME: Record<string, string> = {
   ".html": "text/html",
   ".css": "text/css",
@@ -650,6 +687,26 @@ const server = createServer(
       if ((process.env.AUTH_MODE || "none") !== "simple") {
         res.writeHead(404, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Simple auth is not enabled" }));
+        return;
+      }
+
+      // Rate limit login attempts
+      const clientIp =
+        req.headers["x-forwarded-for"]?.toString().split(",")[0].trim() ||
+        req.socket.remoteAddress ||
+        "unknown";
+      const { allowed, retryAfterSec } = checkLoginRateLimit(clientIp);
+      if (!allowed) {
+        res.writeHead(429, {
+          "Content-Type": "application/json",
+          "Retry-After": String(retryAfterSec),
+        });
+        res.end(
+          JSON.stringify({
+            error: "Too many login attempts. Please try again later.",
+            retryAfterSec,
+          }),
+        );
         return;
       }
 

--- a/lib/auth-simple.ts
+++ b/lib/auth-simple.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, timingSafeEqual, randomUUID } from "node:crypto";
 import { query, isDbConfigured } from "./db.js";
 import { generateTenantKey } from "./encryption.js";
 import type { AuthContext } from "./auth.js";
@@ -14,7 +14,10 @@ interface SimpleAuthUser {
 
 interface SessionPayload {
   username: string;
+  role: Role;
+  sid: string;
   exp: number;
+  iat: number;
 }
 
 export interface SimpleAuthUserInfo {
@@ -27,11 +30,26 @@ export interface SimpleAuthUserInfo {
 const SESSION_COOKIE = "rt_session";
 
 function getSessionSecret(): string {
-  return (
-    process.env.SIMPLE_AUTH_SESSION_SECRET ||
-    process.env.SESSION_SECRET ||
-    "dev-only-simple-auth-secret"
-  );
+  const secret =
+    process.env.SIMPLE_AUTH_SESSION_SECRET || process.env.SESSION_SECRET;
+
+  if (!secret) {
+    if (process.env.AUTH_MODE === "simple") {
+      throw new Error(
+        "SIMPLE_AUTH_SESSION_SECRET must be set when AUTH_MODE=simple. " +
+          'Generate one with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"',
+      );
+    }
+    return "dev-only-simple-auth-secret";
+  }
+
+  if (secret.length < 32) {
+    console.warn(
+      "WARNING: SIMPLE_AUTH_SESSION_SECRET is shorter than 32 characters. Use a stronger secret in production.",
+    );
+  }
+
+  return secret;
 }
 
 function getSessionTtlSeconds(): number {
@@ -40,7 +58,8 @@ function getSessionTtlSeconds(): number {
 }
 
 function getCookieSecure(): boolean {
-  return process.env.SIMPLE_AUTH_COOKIE_SECURE === "true";
+  if (process.env.SIMPLE_AUTH_COOKIE_SECURE === "false") return false;
+  return true;
 }
 
 function base64UrlEncode(input: string): string {
@@ -208,8 +227,14 @@ function deserializeSession(token: string): SessionPayload {
     throw new Error("Invalid session signature");
   }
   const payload = JSON.parse(base64UrlDecode(encoded)) as SessionPayload;
-  if (!payload.username || typeof payload.exp !== "number") {
-    throw new Error("Invalid session payload");
+  if (
+    !payload.username ||
+    typeof payload.exp !== "number" ||
+    !payload.role ||
+    !payload.sid ||
+    typeof payload.iat !== "number"
+  ) {
+    throw new Error("Invalid session payload — please log in again");
   }
   if (payload.exp < Math.floor(Date.now() / 1000)) {
     throw new Error("Session expired");
@@ -227,9 +252,13 @@ export async function loginSimpleUser(
   }
 
   const auth = await ensureSimpleAuthContext(user);
+  const now = Math.floor(Date.now() / 1000);
   const token = serializeSession({
     username: user.username,
-    exp: Math.floor(Date.now() / 1000) + getSessionTtlSeconds(),
+    role: user.role,
+    sid: randomUUID(),
+    exp: now + getSessionTtlSeconds(),
+    iat: now,
   });
 
   return {
@@ -257,6 +286,9 @@ export async function validateSimpleSession(
   const user = findSimpleAuthUser(payload.username);
   if (!user) {
     throw new Error("User no longer exists");
+  }
+  if (user.role !== payload.role) {
+    throw new Error("Session role mismatch — please log in again");
   }
 
   return ensureSimpleAuthContext(user);

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -44,12 +44,51 @@ async function handleRequest(
   handler: Handler,
 ): Promise<void> {
   try {
-    // CORS
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+    // Block TRACE method (prevents XST attacks)
+    if (req.method === "TRACE") {
+      res.writeHead(405, { "Content-Type": "text/plain" });
+      res.end("Method Not Allowed");
+      return;
+    }
+
+    // ── CORS (origin allowlist) ──
+    const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const origin = req.headers.origin;
+    if (origin) {
+      const isAllowed =
+        allowedOrigins.includes(origin) ||
+        (!process.env.CORS_ALLOWED_ORIGINS &&
+          /^https?:\/\/localhost(:\d+)?$/.test(origin));
+      if (isAllowed) {
+        res.setHeader("Access-Control-Allow-Origin", origin);
+        res.setHeader("Vary", "Origin");
+      }
+    }
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     res.setHeader(
       "Access-Control-Allow-Headers",
       "Content-Type, Authorization",
+    );
+
+    // ── Security headers ──
+    res.setHeader(
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+    );
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("X-XSS-Protection", "1; mode=block");
+    res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+    res.setHeader(
+      "Permissions-Policy",
+      "camera=(), microphone=(), geolocation=(), payment=()",
+    );
+    res.setHeader(
+      "Content-Security-Policy",
+      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
     );
 
     if (req.method === "OPTIONS") {


### PR DESCRIPTION
- Add security headers: CSP, HSTS, X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy
- Replace CORS wildcard (*) with origin allowlist via CORS_ALLOWED_ORIGINS env
- Remove DELETE from CORS allowed methods, block TRACE with 405
- Add login rate limiting (5 attempts/15 min per IP, returns 429)
- Default Secure cookie flag to true (opt out with SIMPLE_AUTH_COOKIE_SECURE=false)
- Require strong session secret when AUTH_MODE=simple
- Enrich session token with role, sid, iat claims; validate role consistency