### PR TITLE
Fix CSP blocking inline scripts on deployed dashboard

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -88,7 +88,7 @@ async function handleRequest(
     );
     res.setHeader(
       "Content-Security-Policy",
-      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
     );
 
     if (req.method === "OPTIONS") {


### PR DESCRIPTION
The VAPT security fix (9390ed5) added script-src 'self' which blocks inline <script> tags in the single-file dashboard. Add 'unsafe-inline' to script-src since the dashboard uses inline scripts throughout index.html.