### PR TITLE
Fix cancel button reliability: proper cancelling state and abort checks

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -317,7 +317,7 @@ function readBody(req: IncomingMessage): Promise<string> {
 // ── Job runner ──
 interface Job {
   id: string;
-  status: "queued" | "running" | "done" | "error" | "cancelled";
+  status: "queued" | "running" | "done" | "error" | "cancelled" | "cancelling";
   config: Config;
   progress: RunProgress[];
   report?: Report;
@@ -454,15 +454,19 @@ async function startJob(job: Job): Promise<void> {
     const result = await runRedTeam(
       job.config,
       (p) => {
-        // Don't push progress if already cancelled
-        if (job.status !== "cancelled") job.progress.push(p);
+        // Don't push progress if already cancelled/cancelling
+        if (job.status !== "cancelled" && job.status !== "cancelling") job.progress.push(p);
       },
       undefined,
       ac.signal,
     );
-    // Don't overwrite if already cancelled by user
-    if (job.status === "cancelled") {
-      // Run completed despite cancel — still save partial results
+    // Don't overwrite if already cancelled/cancelling by user
+    if (job.status === "cancelled" || job.status === "cancelling") {
+      job.status = "cancelled";
+      job.error = "Cancelled by user";
+      if (!job.finishedAt) job.finishedAt = new Date().toISOString();
+      activeRuns = Math.max(0, activeRuns - 1);
+      drainQueue();
       console.log("  Run completed after cancel was requested");
     } else {
       job.report = result.report;
@@ -511,8 +515,8 @@ async function startJob(job: Job): Promise<void> {
     const msg = err instanceof Error ? err.message : String(err);
     if (!job.finishedAt) job.finishedAt = new Date().toISOString();
 
-    // Don't overwrite if already cancelled by user
-    if (job.status !== "cancelled") {
+    // Don't overwrite if already cancelled/cancelling by user
+    if (job.status !== "cancelled" && job.status !== "cancelling") {
       if (msg === "Run cancelled") {
         job.status = "cancelled";
         job.error = "Cancelled by user";
@@ -609,7 +613,13 @@ async function startJob(job: Job): Promise<void> {
           job.error = msg;
         }
       }
+    } else {
+      // Was cancelled/cancelling — finalize as cancelled
+      job.status = "cancelled";
+      job.error = "Cancelled by user";
     }
+    activeRuns = Math.max(0, activeRuns - 1);
+    drainQueue();
     if (isDbConfigured() && job.tenantId) {
       query("UPDATE runs SET status=$1, finished_at=$2, error=$3 WHERE id=$4", [
         job.status,
@@ -949,14 +959,14 @@ const server = createServer(
 
       if (job.status === "running" && job.abortController) {
         job.abortController.abort();
-        job.status = "cancelled";
-        job.error = "Cancelled by user";
-        job.finishedAt = new Date().toISOString();
-        // Free up the concurrency slot so queued jobs can start
-        activeRuns = Math.max(0, activeRuns - 1);
-        drainQueue();
+        job.status = "cancelling";
+        job.error = "Cancelling...";
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ runId: id, status: "cancelled" }));
+        res.end(JSON.stringify({ runId: id, status: "cancelling" }));
+      } else if (job.status === "cancelling") {
+        // Already cancelling — return success (idempotent)
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ runId: id, status: "cancelling" }));
       } else if (job.status === "queued") {
         // Remove from queue
         const idx = jobQueue.indexOf(id);
@@ -967,8 +977,9 @@ const server = createServer(
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ runId: id, status: "cancelled" }));
       } else {
-        res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: `Run is already ${job.status}` }));
+        // Run already done/error — still return 200 so UI doesn't show error
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ runId: id, status: job.status }));
       }
       return;
     }

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -1082,6 +1082,7 @@ export async function runRedTeam(
               return { verdict: r.verdict, findings: r.findings };
             },
           );
+          checkAbort();
 
           const lastStep = stepResults[stepResults.length - 1];
           const result = await analyzeResponse(
@@ -1138,6 +1139,7 @@ export async function runRedTeam(
               return { verdict: r.verdict, findings: r.findings };
             },
           );
+          checkAbort();
 
           const lastStep = stepResults[stepResults.length - 1];
           const result = await analyzeResponse(
@@ -1149,6 +1151,7 @@ export async function runRedTeam(
             appContext,
             lastStep.executionTrace,
           );
+          checkAbort();
           result.stepIndex = lastStep.stepIndex;
           result.totalSteps = stepResults.length;
 
@@ -1177,6 +1180,7 @@ export async function runRedTeam(
           );
           const { statusCode, body, timeMs, executionTrace } =
             await executeAttack(config, attack);
+          checkAbort();
           const result = await analyzeResponse(
             config,
             attack,
@@ -1186,6 +1190,7 @@ export async function runRedTeam(
             appContext,
             executionTrace,
           );
+          checkAbort();
 
           log(
             "attacks",


### PR DESCRIPTION
Server:
- Add "cancelling" intermediate state instead of immediately setting "cancelled" (allows in-flight attack to finish gracefully)
- Return 200 (not 400) when cancelling already-finished runs to avoid UI error on race condition
- Properly transition cancelling→cancelled in both success and error paths
- Free concurrency slot and drain queue on cancel

Runner:
- Add checkAbort() after executeAttack, executeMultiTurn, and executeAdaptiveMultiTurn calls so cancellation is detected between attack execution and response analysis, not just between attacks