### PR TITLE
Fix cancel reliability: pass abort signal into multi-turn executors

### DIFF
--- a/lib/attack-runner.ts
+++ b/lib/attack-runner.ts
@@ -810,6 +810,7 @@ export async function executeMultiTurn(
     body: unknown,
     timeMs: number,
   ) => Promise<{ verdict: string; findings: string[] }>,
+  signal?: AbortSignal,
 ): Promise<{
   results: {
     statusCode: number;
@@ -852,6 +853,7 @@ export async function executeMultiTurn(
 
   // Follow-up steps
   for (let i = 0; i < steps.length && results.length < maxSteps; i++) {
+    if (signal?.aborted) throw new Error("Run cancelled");
     if (config.attackConfig.delayBetweenRequestsMs > 0) {
       await sleep(config.attackConfig.delayBetweenRequestsMs);
     }
@@ -912,6 +914,7 @@ export async function executeAdaptiveMultiTurn(
     body: unknown,
     timeMs: number,
   ) => Promise<{ verdict: string; findings: string[] }>,
+  signal?: AbortSignal,
 ): Promise<{
   results: {
     statusCode: number;
@@ -986,6 +989,7 @@ export async function executeAdaptiveMultiTurn(
 
   // Adaptive follow-up turns
   for (let step = 1; step < maxTurns && results.length < maxTurns; step++) {
+    if (signal?.aborted) throw new Error("Run cancelled");
     if (config.attackConfig.delayBetweenRequestsMs > 0) {
       await sleep(config.attackConfig.delayBetweenRequestsMs);
     }

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -1081,6 +1081,7 @@ export async function runRedTeam(
               const r = await analyzeResponse(cfg, atk, sc, b, t, appContext);
               return { verdict: r.verdict, findings: r.findings };
             },
+            signal,
           );
           checkAbort();
 
@@ -1138,6 +1139,7 @@ export async function runRedTeam(
               const r = await analyzeResponse(cfg, atk, sc, b, t, appContext);
               return { verdict: r.verdict, findings: r.findings };
             },
+            signal,
           );
           checkAbort();
 
@@ -1312,6 +1314,7 @@ export async function runRedTeam(
                     );
                     return { verdict: r.verdict, findings: r.findings };
                   },
+                  signal,
                 );
 
               const lastStep = stepResults[stepResults.length - 1];
@@ -1367,6 +1370,7 @@ export async function runRedTeam(
                   );
                   return { verdict: r.verdict, findings: r.findings };
                 },
+                signal,
               );
 
               const lastStep = stepResults[stepResults.length - 1];


### PR DESCRIPTION
executeMultiTurn and executeAdaptiveMultiTurn were not receiving the abort signal, so cancel could only take effect between attacks, not between turns within a multi-turn conversation. Now both functions check signal.aborted at each turn boundary for responsive cancellation.