### PR TITLE
Fix cancel: set status to cancelled immediately and persist to DB

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -12495,11 +12495,11 @@
       async function cancelRun(runId) {
         if (!confirm("Are you sure you want to cancel this run? This cannot be undone.")) return;
 
-        // Immediately show "cancelling" state so user gets instant feedback
+        // Immediately show "cancelled" state so user gets instant feedback
         const cached = runDataCache.get(runId);
         if (cached) {
-          cached.status = "cancelling";
-          cached.error = "Cancelling...";
+          cached.status = "cancelled";
+          cached.error = "Cancelled by user";
         }
         renderSidebarRuns();
         if (currentTab === "runs") renderRunsTab();
@@ -12508,7 +12508,7 @@
           const resp = await fetch(`/api/run/${runId}`, { method: "DELETE" });
           const data = await resp.json();
           if (resp.ok && cached) {
-            cached.status = data.status === "cancelling" ? "cancelled" : (data.status || "cancelled");
+            cached.status = data.status || "cancelled";
             cached.error = "Cancelled by user";
           } else if (cached) {
             // Request failed — revert to previous state

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -317,7 +317,7 @@ function readBody(req: IncomingMessage): Promise<string> {
 // ── Job runner ──
 interface Job {
   id: string;
-  status: "queued" | "running" | "done" | "error" | "cancelled" | "cancelling";
+  status: "queued" | "running" | "done" | "error" | "cancelled";
   config: Config;
   progress: RunProgress[];
   report?: Report;
@@ -454,16 +454,14 @@ async function startJob(job: Job): Promise<void> {
     const result = await runRedTeam(
       job.config,
       (p) => {
-        // Don't push progress if already cancelled/cancelling
-        if (job.status !== "cancelled" && job.status !== "cancelling") job.progress.push(p);
+        // Don't push progress if already cancelled
+        if (job.status !== "cancelled") job.progress.push(p);
       },
       undefined,
       ac.signal,
     );
-    // Don't overwrite if already cancelled/cancelling by user
-    if (job.status === "cancelled" || job.status === "cancelling") {
-      job.status = "cancelled";
-      job.error = "Cancelled by user";
+    // Don't overwrite if already cancelled by user
+    if (job.status === "cancelled") {
       if (!job.finishedAt) job.finishedAt = new Date().toISOString();
       activeRuns = Math.max(0, activeRuns - 1);
       drainQueue();
@@ -515,8 +513,8 @@ async function startJob(job: Job): Promise<void> {
     const msg = err instanceof Error ? err.message : String(err);
     if (!job.finishedAt) job.finishedAt = new Date().toISOString();
 
-    // Don't overwrite if already cancelled/cancelling by user
-    if (job.status !== "cancelled" && job.status !== "cancelling") {
+    // Don't overwrite if already cancelled by user
+    if (job.status !== "cancelled") {
       if (msg === "Run cancelled") {
         job.status = "cancelled";
         job.error = "Cancelled by user";
@@ -614,9 +612,7 @@ async function startJob(job: Job): Promise<void> {
         }
       }
     } else {
-      // Was cancelled/cancelling — finalize as cancelled
-      job.status = "cancelled";
-      job.error = "Cancelled by user";
+      // Was cancelled — already finalized
     }
     activeRuns = Math.max(0, activeRuns - 1);
     drainQueue();
@@ -959,14 +955,20 @@ const server = createServer(
 
       if (job.status === "running" && job.abortController) {
         job.abortController.abort();
-        job.status = "cancelling";
-        job.error = "Cancelling...";
+        job.status = "cancelled";
+        job.error = "Cancelled by user";
+        job.finishedAt = new Date().toISOString();
+        if (isDbConfigured() && job.tenantId) {
+          query("UPDATE runs SET status=$1, finished_at=$2, error=$3 WHERE id=$4", [
+            job.status, job.finishedAt, job.error, job.id,
+          ]).catch(() => {});
+        }
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ runId: id, status: "cancelling" }));
-      } else if (job.status === "cancelling") {
-        // Already cancelling — return success (idempotent)
+        res.end(JSON.stringify({ runId: id, status: "cancelled" }));
+      } else if (job.status === "cancelled") {
+        // Already cancelled — return success (idempotent)
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ runId: id, status: "cancelling" }));
+        res.end(JSON.stringify({ runId: id, status: "cancelled" }));
       } else if (job.status === "queued") {
         // Remove from queue
         const idx = jobQueue.indexOf(id);
@@ -974,6 +976,11 @@ const server = createServer(
         job.status = "cancelled";
         job.error = "Cancelled by user";
         job.finishedAt = new Date().toISOString();
+        if (isDbConfigured() && job.tenantId) {
+          query("UPDATE runs SET status=$1, finished_at=$2, error=$3 WHERE id=$4", [
+            job.status, job.finishedAt, job.error, job.id,
+          ]).catch(() => {});
+        }
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ runId: id, status: "cancelled" }));
       } else {


### PR DESCRIPTION
Previously cancel set status to "cancelling" without updating the DB, so a page refresh would show the run as still "running". Now the cancel handler immediately sets status to "cancelled", persists to DB, and the frontend reflects this instantly without an intermediate state.