### PR TITLE
Only poll active runs, stop polling finished/cancelled runs on click

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5482,8 +5482,12 @@
           selectedRunId = null;
         } else {
           selectedRunId = runId;
-          // Start polling if not already
-          pollRun(runId);
+          // Only poll active runs
+          const cached = runDataCache.get(runId);
+          const st = cached?.status;
+          if (st === "running" || st === "queued") {
+            pollRun(runId);
+          }
         }
         renderRunsTab();
       }


### PR DESCRIPTION
toggleRunDetail was starting pollRun for every run including done and cancelled ones, causing unnecessary network requests.