### PR TITLE
Fix cancel + reduce excessive polling requests

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5213,19 +5213,6 @@
       async function renderRunsTab() {
         const panel = document.getElementById("runsPanel");
 
-        // Merge in-memory runs with server-side runs list
-        try {
-          const resp = await fetch("/api/runs");
-          if (resp.ok) {
-            const serverRuns = await resp.json();
-            for (const run of serverRuns) {
-              if (!runDataCache.has(run.runId)) {
-                runDataCache.set(run.runId, run);
-              }
-            }
-          }
-        } catch {}
-
         // Filter out runs with invalid/missing dates, then sort newest first
         const allRuns = [...runDataCache.entries()]
           .filter(function(entry) {
@@ -12052,6 +12039,11 @@
 
       function pollRun(runId) {
         if (pollingRuns.has(runId)) return;
+        // Don't poll terminal runs
+        var existing = runDataCache.get(runId);
+        if (existing && (existing.status === "done" || existing.status === "error" || existing.status === "cancelled")) {
+          return;
+        }
         pollingRuns.add(runId);
 
         let progressOffset = 0;
@@ -12069,8 +12061,10 @@
               cached.progress = [...(cached.progress || []), ...data.progress];
             }
             const merged = cached || data;
-            // Always update non-progress fields
-            merged.status = data.status;
+            // Don't let server "running" overwrite local "cancelled" (race window)
+            if (merged.status !== "cancelled" || data.status === "cancelled") {
+              merged.status = data.status;
+            }
             merged.error = data.error;
             merged.finishedAt = data.finishedAt;
             merged.summary = data.summary;
@@ -12451,12 +12445,8 @@
           const resp = await fetch("/api/runs");
           const runs = await resp.json();
           for (const run of runs) {
-            if (
-              run.status === "queued" ||
-              run.status === "running" ||
-              run.status === "error"
-            ) {
-              // Fetch full progress for active/recent runs
+            if (run.status === "queued" || run.status === "running") {
+              // Only fetch full progress for actively running jobs
               try {
                 const fullResp = await fetch(`/api/run/${run.runId}?since=0`);
                 const fullData = await fullResp.json();
@@ -12464,9 +12454,10 @@
               } catch {
                 runDataCache.set(run.runId, { ...run, progress: [] });
               }
-              if (run.status === "queued" || run.status === "running") {
-                pollRun(run.runId);
-              }
+              pollRun(run.runId);
+            } else if (!runDataCache.has(run.runId)) {
+              // For done/error/cancelled, use list data directly (no extra fetch)
+              runDataCache.set(run.runId, { ...run, progress: [] });
             }
           }
           renderSidebarRuns();

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -508,8 +508,8 @@ async function startJob(job: Job): Promise<void> {
           job.reportFile = paths.jsonPath;
         } catch {}
       }
-      job.status = "done";
-      if (isDbConfigured() && job.tenantId) {
+      if (!job._cancelled) job.status = "done";
+      if (isDbConfigured() && job.tenantId && !job._cancelled) {
         query("UPDATE runs SET status=$1, finished_at=$2 WHERE id=$3", [
           "done",
           job.finishedAt,
@@ -522,8 +522,8 @@ async function startJob(job: Job): Promise<void> {
     if (!job.finishedAt) job.finishedAt = new Date().toISOString();
 
     // Don't overwrite if already cancelled by user
-    console.log(`  [CANCEL-CHECK] runRedTeam threw "${msg}", job.status=${job.status}`);
-    if (job.status !== "cancelled") {
+    console.log(`  [CANCEL-CHECK] runRedTeam threw "${msg}", job.status=${job.status}, _cancelled=${job._cancelled}`);
+    if (!job._cancelled && job.status !== "cancelled") {
       if (msg === "Run cancelled") {
         job.status = "cancelled";
         job.error = "Cancelled by user";
@@ -963,45 +963,26 @@ const server = createServer(
         return;
       }
 
-      if ((job.status === "running" || !job._cancelled) && job.abortController) {
-        console.log(`  [CANCEL] Aborting job ${id}, current status: ${job.status}`);
+      // Unconditionally cancel — abort if controller exists, always set _cancelled
+      console.log(`  [CANCEL] Cancelling job ${id}, current status: ${job.status}`);
+      if (job.abortController) {
         job.abortController.abort();
-        job._cancelled = true;
-        job.status = "cancelled";
-        job.error = "Cancelled by user";
-        job.finishedAt = new Date().toISOString();
-        console.log(`  [CANCEL] Job ${id} status set to: ${job.status}, _cancelled=true`);
-        if (isDbConfigured() && job.tenantId) {
-          query("UPDATE runs SET status=$1, finished_at=$2, error=$3 WHERE id=$4", [
-            job.status, job.finishedAt, job.error, job.id,
-          ]).catch(() => {});
-        }
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ runId: id, status: "cancelled" }));
-      } else if (job.status === "cancelled") {
-        // Already cancelled — return success (idempotent)
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ runId: id, status: "cancelled" }));
-      } else if (job.status === "queued") {
-        // Remove from queue
+      }
+      if (job.status === "queued") {
         const idx = jobQueue.indexOf(id);
         if (idx !== -1) jobQueue.splice(idx, 1);
-        job._cancelled = true;
-        job.status = "cancelled";
-        job.error = "Cancelled by user";
-        job.finishedAt = new Date().toISOString();
-        if (isDbConfigured() && job.tenantId) {
-          query("UPDATE runs SET status=$1, finished_at=$2, error=$3 WHERE id=$4", [
-            job.status, job.finishedAt, job.error, job.id,
-          ]).catch(() => {});
-        }
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ runId: id, status: "cancelled" }));
-      } else {
-        // Run already done/error — still return 200 so UI doesn't show error
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ runId: id, status: job.status }));
       }
+      job._cancelled = true;
+      job.status = "cancelled";
+      job.error = "Cancelled by user";
+      if (!job.finishedAt) job.finishedAt = new Date().toISOString();
+      if (isDbConfigured() && job.tenantId) {
+        query("UPDATE runs SET status=$1, finished_at=$2, error=$3 WHERE id=$4", [
+          "cancelled", job.finishedAt, job.error, job.id,
+        ]).catch(() => {});
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ runId: id, status: "cancelled" }));
       return;
     }
 


### PR DESCRIPTION
Cancel bug: The DELETE handler required job.abortController to exist to set _cancelled=true. But startJob's finally block clears the controller, so if the run finishes before DELETE is processed, _cancelled was never set and status reverted on refresh. Fix:
- Cancel unconditionally sets _cancelled=true regardless of state
- Guard job.status="done" with if(!job._cancelled) to prevent overwrite
- Guard catch block with _cancelled check too

Polling bug: renderRunsTab fetched GET /api/runs on every render (redundant with refreshActiveRuns). refreshActiveRuns fetched individual run detail for error/done runs too. Fix:
- Remove redundant /api/runs fetch from renderRunsTab
- Only fetch individual run detail for running/queued jobs
- Add terminal-status guard to pollRun to prevent polling done runs
- Prevent polling from overwriting local "cancelled" with "running"