### PR TITLE
Pass abort signal into planAttacks for responsive cancel during planning

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -462,7 +462,7 @@ async function startJob(job: Job): Promise<void> {
       job.config,
       (p) => {
         // Don't push progress if already cancelled
-        if (job.status !== "cancelled") job.progress.push(p);
+        if (!job._cancelled) job.progress.push(p);
       },
       undefined,
       ac.signal,

--- a/lib/attack-planner.ts
+++ b/lib/attack-planner.ts
@@ -31,12 +31,14 @@ import { formatErrorDetails } from "./error-utils.js";
 async function runPlanWithConcurrency<T>(
   tasks: (() => Promise<T>)[],
   maxConcurrency: number,
+  signal?: AbortSignal,
 ): Promise<T[]> {
   const results: T[] = new Array(tasks.length);
   let nextIndex = 0;
 
   async function worker(): Promise<void> {
     while (nextIndex < tasks.length) {
+      if (signal?.aborted) throw new Error("Run cancelled");
       const i = nextIndex++;
       results[i] = await tasks[i]();
     }
@@ -142,6 +144,7 @@ export async function planAttacks(
   previousResults: AttackResult[],
   round: number,
   defenseProfiles?: Map<AttackCategory, CategoryDefenseProfile>,
+  signal?: AbortSignal,
 ): Promise<Attack[]> {
   const allAttacks: Attack[] = [];
   const totalModules = modules.length;
@@ -159,6 +162,7 @@ export async function planAttacks(
 
   const planTasks = modules.map((mod) => {
     return async (): Promise<Attack[]> => {
+      if (signal?.aborted) throw new Error("Run cancelled");
       sharedPlanIndex.value++;
       const progress = `[${sharedPlanIndex.value}/${totalModules}]`;
       const catPrefix = categoryParallelism > 1 ? `[${mod.category}] ` : "";
@@ -216,6 +220,7 @@ export async function planAttacks(
   const planResults = await runPlanWithConcurrency(
     planTasks,
     categoryParallelism,
+    signal,
   );
   for (const categoryAttacks of planResults) {
     allAttacks.push(...categoryAttacks);

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -972,6 +972,7 @@ export async function runRedTeam(
             allPreviousResults,
             round,
             defenseProfiles,
+            signal,
           );
     } finally {
       console.log = origLog;


### PR DESCRIPTION
planAttacks was the main bottleneck — it runs multiple LLM calls per category but never checked the abort signal. Now the signal is threaded through planAttacks → runPlanWithConcurrency, checked between each category planning task and between each concurrency worker iteration. Also use _cancelled flag for progress callback guard.