### PR TITLE
Allow DELETE method for cancel + all previous fixes

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -45,7 +45,7 @@ async function handleRequest(
 ): Promise<void> {
   try {
     // Block dangerous HTTP methods (TRACE, PUT, DELETE, PATCH, CONNECT)
-    const allowedMethods = new Set(["GET", "POST", "OPTIONS", "HEAD"]);
+    const allowedMethods = new Set(["GET", "POST", "OPTIONS", "HEAD", "DELETE"]);
     if (!allowedMethods.has(req.method || "")) {
       res.writeHead(405, {
         "Content-Type": "text/plain",
@@ -98,7 +98,7 @@ async function handleRequest(
     res.removeHeader("X-Powered-By");
 
     if (req.method === "OPTIONS") {
-      res.setHeader("Access-Control-Allow-Methods", "GET, POST, HEAD");
+      res.setHeader("Access-Control-Allow-Methods", "GET, POST, HEAD, DELETE");
       res.setHeader(
         "Access-Control-Allow-Headers",
         "Content-Type, Authorization",


### PR DESCRIPTION
## Summary
Root cause: middleware blocked DELETE method (405), so cancel requests never reached the server. Frontend silently swallowed the error.

- Allow DELETE in middleware allowedMethods
- All previous cancel fixes (cancelledRunIds, _cancelled flag, DB guards, abort signal threading)
- Verdict patterns for safety classifier
- Reduced polling

## Test plan
- [ ] Click Cancel on a running job → should persist after refresh
- [ ] Check Railway logs for `[CANCEL]` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)