### PR TITLE
Fix Risk tab layout gap: let table and panel fill available space

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1311,7 +1311,8 @@
 
       /* Full-width panel (Dashboard, Runs, Audit) */
       .full-panel {
-        height: 100%;
+        min-height: 100%;
+        height: auto;
         overflow-y: auto;
         padding: 32px;
       }
@@ -6348,7 +6349,7 @@
           reports.length +
           " reports</div>" +
           "</div>" +
-          '<div style="max-height:400px;overflow-y:auto;">' +
+          '<div style="overflow-y:auto;">' +
           '<table class="u-w-full u-text-base" style="border-collapse:collapse;" id="' +
           tableId +
           '">' +


### PR DESCRIPTION
- Remove max-height:400px on report selector table so it fills the panel
- Change full-panel from height:100% to min-height:100% so content stretches naturally without leaving a gap at the bottom