### PR TITLE
Fix scroll: use viewport-relative max-height for report selector table

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1311,8 +1311,7 @@
 
       /* Full-width panel (Dashboard, Runs, Audit) */
       .full-panel {
-        min-height: 100%;
-        height: auto;
+        height: 100%;
         overflow-y: auto;
         padding: 32px;
       }
@@ -6349,7 +6348,7 @@
           reports.length +
           " reports</div>" +
           "</div>" +
-          '<div style="overflow-y:auto;">' +
+          '<div style="max-height:calc(100vh - 280px);overflow-y:auto;">' +
           '<table class="u-w-full u-text-base" style="border-collapse:collapse;" id="' +
           tableId +
           '">' +


### PR DESCRIPTION
Previous fix removed max-height entirely, breaking scroll. Now uses calc(100vh - 280px) so the table fills available space and scrolls within it. Reverted full-panel back to height:100%.