### PR TITLE
Fix CART UI issues across dashboard, scans, reports, compliance, poli…

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -385,6 +385,15 @@ const RESPONSE_BODY_SLIM_LEN = 2000;
  * downloads) is never mutated. Events needing no trim are passed through by
  * reference (cheap — incremental polls usually carry only a handful of events).
  */
+/** Re-indent an already-serialized JSON string for human-readable downloads. */
+function prettyJson(serialized: string): string {
+  try {
+    return JSON.stringify(JSON.parse(serialized), null, 2);
+  } catch {
+    return serialized;
+  }
+}
+
 function slimProgressForTransit(events: unknown[]): unknown[] {
   const trim = (s: unknown): string | null =>
     typeof s === "string" && s.length > RESPONSE_BODY_SLIM_LEN
@@ -1134,20 +1143,69 @@ const server = createServer(
         return;
       }
 
-      // Job not in memory — try to load config from DB or file (for rerun)
-      if (includeConfig) {
-        const savedConfig = await loadRunConfig(id, ctx?.tenantId);
-        if (savedConfig) {
+      // Job not in memory — this is a historical run from a previous server
+      // lifecycle. Surface its linked report so the UI's expandable detail row
+      // shows the attack results and a "View Report" link instead of nothing.
+      const savedConfig = includeConfig
+        ? await loadRunConfig(id, ctx?.tenantId)
+        : null;
+
+      let reportFilename: string | undefined;
+      if (isDbConfigured() && ctx?.tenantId) {
+        try {
+          const rep = await query<{ filename: string }>(
+            "SELECT filename FROM reports WHERE run_id=$1 AND tenant_id=$2 ORDER BY created_at DESC LIMIT 1",
+            [id, ctx.tenantId],
+          );
+          if (rep.rows.length > 0) reportFilename = rep.rows[0].filename;
+        } catch (err) {
+          console.error(`  [run detail] report lookup failed for ${id}:`, err);
+        }
+      }
+
+      if (reportFilename) {
+        const loaded = await loadReportRecord(reportFilename, ctx?.tenantId);
+        if (loaded) {
+          const report = normalizeReportSteps(loaded.report) as any;
+          const rounds = Array.isArray(report.rounds) ? report.rounds : [];
+          const results: any[] = rounds.flatMap((rd: any) =>
+            Array.isArray(rd.results) ? rd.results : [],
+          );
+          // Lightweight progress events matching the live-run event shape the
+          // UI consumes (attackName / category / verdict per result).
+          const progress = results.map((r, i) => ({
+            index: i,
+            attackName: r.attack?.name ?? r.attackName ?? "—",
+            category: r.attack?.category ?? r.category ?? "",
+            verdict: r.verdict ?? "",
+          }));
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(
             JSON.stringify({
               runId: id,
               status: "done",
-              config: savedConfig,
+              reportFile: reportFilename,
+              summary: report.summary,
+              progressTotal: progress.length,
+              progress,
+              ...(savedConfig ? { config: savedConfig } : {}),
             }),
           );
           return;
         }
+      }
+
+      // No report found — fall back to config-only response (for rerun/edit).
+      if (savedConfig) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            runId: id,
+            status: "done",
+            config: savedConfig,
+          }),
+        );
+        return;
       }
 
       res.writeHead(404, { "Content-Type": "application/json" });
@@ -1277,13 +1335,23 @@ const server = createServer(
               const finishedAt = row.finished_at ? new Date(row.finished_at).toISOString() : null;
               // Skip rows with no valid date
               if (!startedAt) continue;
+              // Runs only ever execute in this process's in-memory `jobs` map. A DB
+              // row still flagged running/queued but absent from memory is orphaned
+              // (the server restarted mid-run), so it is NOT actually active.
+              // Coerce it to a terminal state so the "N active" counters reflect
+              // reality instead of inflating with stale runs.
+              const rawStatus = row.status || "done";
+              const orphanedActive =
+                rawStatus === "running" || rawStatus === "queued";
               runs.push({
                 runId: row.id,
-                status: row.status || "done",
+                status: orphanedActive ? "error" : rawStatus,
                 startedAt,
                 finishedAt,
                 targetUrl: row.target_url || "unknown",
-                error: row.error || null,
+                error: orphanedActive
+                  ? row.error || "Interrupted — server restarted before completion"
+                  : row.error || null,
                 progressCount: 0,
                 reportFile: undefined,
                 summary: undefined,
@@ -1674,7 +1742,9 @@ const server = createServer(
             headers["Content-Disposition"] = `attachment; filename="${filename}"`;
           }
           res.writeHead(200, headers);
-          res.end(cached.body);
+          // Pretty-print downloads so the saved file is readable (the cached body
+          // is minified for fast browser transit).
+          res.end(download ? prettyJson(cached.body) : cached.body);
           return;
         }
 
@@ -1744,7 +1814,8 @@ const server = createServer(
           headers["Content-Disposition"] = `attachment; filename="${filename}"`;
         }
         res.writeHead(200, headers);
-        res.end(body);
+        // Pretty-print downloads so the saved file is readable, not one long line.
+        res.end(download ? prettyJson(body) : body);
       } catch (err) {
         console.error(`  Failed to load report ${filename}:`, err);
         res.writeHead(500, { "Content-Type": "application/json" });
@@ -2031,6 +2102,12 @@ const server = createServer(
             // No config.json — use defaults; API keys come from env vars
           }
         }
+        // Provider names are case-insensitive by nature, but createProvider()
+        // matches lowercase keys exactly. The UI sends capitalized labels like
+        // "Anthropic"/"OpenAI", so normalize before resolving the provider —
+        // otherwise every item throws "Unknown LLM provider" and the analysis
+        // silently fails after the NDJSON headers are already sent.
+        judgeProvider = String(judgeProvider).toLowerCase();
         const llm = getJudgeProvider({
           attackConfig: { judgeProvider, llmProvider: judgeProvider },
         } as Config);

--- a/dashboard/ui/src/api/types.ts
+++ b/dashboard/ui/src/api/types.ts
@@ -253,6 +253,8 @@ export interface GuardrailResultLeg {
   latency_ms?: number;
   response_text?: string;
   guardrail_verdict?: string;
+  /** Per-leg verdict emitted by the guardrail eval, e.g. "guardrail_blocked", "benign_answer". */
+  verdict?: string;
 }
 
 export interface GuardrailAssessment {

--- a/dashboard/ui/src/pages/DashboardPage/index.tsx
+++ b/dashboard/ui/src/pages/DashboardPage/index.tsx
@@ -201,19 +201,29 @@ export default function DashboardPage() {
   const maxTargetVulns = topTargets.length > 0 ? topTargets[0][1] : 1;
 
   // ── filtered scans for table ──
-  const recentScans = reportsMeta.slice(0, 20);
+  // Use the full report set so the tab counts (derived from scoreBuckets over
+  // all reports) stay consistent with what the table actually shows. Slicing to
+  // a "recent 20" here made "All Scans" disagree with the severity tab counts.
+  const allScans = reportsMeta;
   const filteredScans =
     tableFilter === "all"
-      ? recentScans
-      : recentScans.filter((r) => getSeverity(r.score) === tableFilter);
+      ? allScans
+      : allScans.filter((r) => getSeverity(r.score) === tableFilter);
 
   const filterTabs: { key: "all" | SeverityLevel; label: string; count: number }[] = [
-    { key: "all", label: "All Scans", count: recentScans.length },
+    { key: "all", label: "All Scans", count: allScans.length },
     { key: "critical", label: "Critical", count: scoreBuckets.critical },
     { key: "high", label: "High", count: scoreBuckets.high },
     { key: "medium", label: "Medium", count: scoreBuckets.medium },
     { key: "low", label: "Low", count: scoreBuckets.low },
   ];
+
+  const SEVERITY_EMPTY_LABEL: Record<SeverityLevel, string> = {
+    critical: "critical",
+    high: "high",
+    medium: "medium",
+    low: "low",
+  };
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">
@@ -293,6 +303,13 @@ export default function DashboardPage() {
       </div>
 
       {/* ── Row 2: Severity breakdown (Pepper-style colored dot + number row) ── */}
+      <div>
+      <div className="flex items-baseline justify-between mb-2">
+        <h2 className="text-sm font-semibold text-foreground">Scans by Severity</h2>
+        <span className="text-[11px] text-muted-foreground">
+          Scans grouped by overall risk score
+        </span>
+      </div>
       <div className="grid grid-cols-4 gap-4">
         {(["critical", "high", "medium", "low"] as const).map((level) => {
           const cfg = SEVERITY_CONFIG[level];
@@ -310,6 +327,7 @@ export default function DashboardPage() {
             </Card>
           );
         })}
+      </div>
       </div>
 
       {/* ── Row 3: Findings table with filter tabs ── */}
@@ -404,10 +422,23 @@ export default function DashboardPage() {
           ) : (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Shield className="w-10 h-10 text-muted-foreground/30 mb-3" />
-              <p className="text-sm font-medium text-muted-foreground">No scans found</p>
-              <p className="text-xs text-muted-foreground/70 mt-1">
-                Run your first security scan to see results here
-              </p>
+              {tableFilter === "all" ? (
+                <>
+                  <p className="text-sm font-medium text-muted-foreground">No scans found</p>
+                  <p className="text-xs text-muted-foreground/70 mt-1">
+                    Run your first security scan to see results here
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-sm font-medium text-muted-foreground">
+                    No {SEVERITY_EMPTY_LABEL[tableFilter]} severity scans
+                  </p>
+                  <p className="text-xs text-muted-foreground/70 mt-1">
+                    No scans fall into the {SEVERITY_EMPTY_LABEL[tableFilter]} severity range
+                  </p>
+                </>
+              )}
             </div>
           )}
         </CardContent>

--- a/dashboard/ui/src/pages/GuardrailsPage/index.tsx
+++ b/dashboard/ui/src/pages/GuardrailsPage/index.tsx
@@ -49,7 +49,23 @@ function getVerdict(r: GuardrailResult): string {
 }
 
 function isBlocked(r: GuardrailResult): boolean {
-  return r.assessment?.blocked ?? r.blocked ?? false;
+  // Primary signal: the with-guardrails leg. This mirrors the server's
+  // extractGuardrailSummary() detection so the UI stops under-reporting blocks
+  // to zero. (`assessment` in real reports is a free-text string, so the old
+  // `assessment.blocked` / top-level `blocked` checks were always falsy.)
+  const g = r.with_guardrails;
+  if (g) {
+    const verdict = g.verdict ?? g.guardrail_verdict;
+    if (verdict) {
+      return verdict === "guardrail_blocked" || verdict === "safe_refusal_or_redirect";
+    }
+    if (g.status_code === 400 || g.status_code === 403) return true;
+    if ((g.response_text || "").toLowerCase().includes("blocked by votal guardrails")) {
+      return true;
+    }
+  }
+  // Legacy fallbacks for older flat report shapes.
+  return (typeof r.assessment === "object" && r.assessment?.blocked) || r.blocked || false;
 }
 
 function isBad(r: GuardrailResult): boolean {

--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -38,6 +38,7 @@ import {
   Braces,
   Upload,
   Loader2,
+  Search,
 } from "lucide-react";
 
 /* ─── constants ─── */
@@ -60,6 +61,7 @@ const ATTACK_MODES = [
 ] as const;
 
 const AUTH_METHODS = [
+  { value: "none", label: "No Auth (public)" },
   { value: "api_key", label: "API Key" },
   { value: "body_role", label: "Body Role" },
   { value: "jwt", label: "JWT" },
@@ -232,6 +234,8 @@ export default function NewScanPage() {
   // ── Attack config ──
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedStrategies, setSelectedStrategies] = useState<string[]>([]);
+  const [categorySearch, setCategorySearch] = useState("");
+  const [strategySearch, setStrategySearch] = useState("");
   const [adaptiveRounds, setAdaptiveRounds] = useState(3);
   const [maxAttacksPerCategory, setMaxAttacksPerCategory] = useState(15);
   const [concurrency, setConcurrency] = useState(3);
@@ -731,8 +735,25 @@ export default function NewScanPage() {
                   </div>
                 )}
 
+                <div className="relative mb-3 max-w-xs">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+                  <input
+                    type="text"
+                    value={categorySearch}
+                    onChange={(e) => setCategorySearch(e.target.value)}
+                    placeholder="Search categories..."
+                    className="w-full pl-9 pr-3 py-1.5 bg-background border border-border rounded-lg text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                  />
+                </div>
+
                 <div className="flex flex-wrap gap-2">
-                  {ref.categories.map((cat) => {
+                  {ref.categories
+                    .filter((cat) =>
+                      !categorySearch ||
+                      prettyCat(cat).toLowerCase().includes(categorySearch.toLowerCase()) ||
+                      cat.toLowerCase().includes(categorySearch.toLowerCase()),
+                    )
+                    .map((cat) => {
                     const selected = selectedCategories.includes(cat);
                     return (
                       <button
@@ -792,7 +813,29 @@ export default function NewScanPage() {
                   </div>
                 </div>
 
-                {Object.entries(strategyGroups).map(([level, strategies]) => (
+                <div className="relative mb-3 max-w-xs">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+                  <input
+                    type="text"
+                    value={strategySearch}
+                    onChange={(e) => setStrategySearch(e.target.value)}
+                    placeholder="Search strategies..."
+                    className="w-full pl-9 pr-3 py-1.5 bg-background border border-border rounded-lg text-xs text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+                  />
+                </div>
+
+                {Object.entries(strategyGroups)
+                  .map(([level, strategies]) => [
+                    level,
+                    strategies.filter(
+                      (s) =>
+                        !strategySearch ||
+                        s.name.toLowerCase().includes(strategySearch.toLowerCase()) ||
+                        s.slug.toLowerCase().includes(strategySearch.toLowerCase()),
+                    ),
+                  ] as [string, StrategyInfo[]])
+                  .filter(([, strategies]) => strategies.length > 0)
+                  .map(([level, strategies]) => (
                   <div key={level} className="mb-4 last:mb-0">
                     <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
                       {level}
@@ -991,9 +1034,13 @@ export default function NewScanPage() {
                         key={m.value}
                         type="button"
                         onClick={() =>
-                          setAuthMethods((prev) =>
-                            selected ? prev.filter((x) => x !== m.value) : [...prev, m.value],
-                          )
+                          setAuthMethods((prev) => {
+                            if (selected) return prev.filter((x) => x !== m.value);
+                            // "No Auth" is exclusive — selecting it clears the
+                            // others, and selecting any real method clears it.
+                            if (m.value === "none") return ["none"];
+                            return [...prev.filter((x) => x !== "none"), m.value];
+                          })
                         }
                         className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-all ${
                           selected

--- a/dashboard/ui/src/pages/ReportsPage/index.tsx
+++ b/dashboard/ui/src/pages/ReportsPage/index.tsx
@@ -106,11 +106,45 @@ function getRoundNumber(round: { round?: number; roundNumber?: number }): number
   return round.round ?? round.roundNumber ?? 0;
 }
 
-function verdictVariant(v: string | undefined | null): "destructive" | "default" | "secondary" {
+/*
+ * Verdict semantics (from lib/response-analyzer.ts — the source of truth):
+ *   PASS    = the attack SUCCEEDED → a vulnerability was found (BAD, red)
+ *   FAIL    = the agent DEFENDED → the attack was blocked (GOOD, green)
+ *   PARTIAL = partial leak / incomplete defense
+ * The raw verdict strings are kept in the data; we only relabel/recolor them in
+ * the UI so a held defense reads as a positive outcome instead of a scary "FAIL".
+ */
+
+/** Defender-friendly display label for a raw verdict. */
+function verdictLabel(v: string | undefined | null): string {
   const l = (v ?? "").toUpperCase();
-  if (l === "FAIL") return "destructive";
-  if (l === "PASS") return "default";
-  return "secondary";
+  if (l === "PASS") return "Vulnerable";
+  if (l === "FAIL") return "Defended";
+  if (l === "PARTIAL") return "Partial";
+  if (l === "ERROR") return "Error";
+  return v ?? "—";
+}
+
+/** Badge variant + extra classes for a raw verdict. */
+function verdictBadge(v: string | undefined | null): {
+  variant: "destructive" | "default" | "secondary" | "outline";
+  className: string;
+} {
+  const l = (v ?? "").toUpperCase();
+  if (l === "PASS") return { variant: "destructive", className: "" };
+  if (l === "FAIL")
+    return {
+      variant: "outline",
+      className:
+        "text-emerald-600 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800",
+    };
+  if (l === "PARTIAL")
+    return {
+      variant: "outline",
+      className:
+        "text-amber-600 dark:text-amber-400 border-amber-200 dark:border-amber-800",
+    };
+  return { variant: "secondary", className: "" };
 }
 
 function prettyCat(cat: string) {
@@ -119,8 +153,8 @@ function prettyCat(cat: string) {
 
 function verdictDotColor(v: string | undefined | null) {
   const l = (v ?? "").toUpperCase();
-  if (l === "PASS") return "bg-emerald-500";
-  if (l === "FAIL") return "bg-red-500";
+  if (l === "PASS") return "bg-red-500";
+  if (l === "FAIL") return "bg-emerald-500";
   if (l === "PARTIAL") return "bg-amber-500";
   return "bg-gray-400";
 }
@@ -195,8 +229,8 @@ function ReportsGrid() {
                     <TableHead>Target URL</TableHead>
                     <TableHead className="w-[180px]">Date</TableHead>
                     <TableHead className="w-[90px] text-center">Attacks</TableHead>
-                    <TableHead className="w-[80px] text-center">Passed</TableHead>
-                    <TableHead className="w-[80px] text-center">Failed</TableHead>
+                    <TableHead className="w-[90px] text-center">Vulnerable</TableHead>
+                    <TableHead className="w-[90px] text-center">Defended</TableHead>
                     <TableHead className="w-[80px] text-center">Errors</TableHead>
                     <TableHead className="w-[60px]" />
                   </TableRow>
@@ -232,12 +266,12 @@ function ReportsGrid() {
                         {r.totalAttacks}
                       </TableCell>
                       <TableCell className="text-center">
-                        <span className="text-sm tabular-nums text-green-600 dark:text-green-400 font-medium">
+                        <span className="text-sm tabular-nums text-red-600 dark:text-red-400 font-medium">
                           {r.passed}
                         </span>
                       </TableCell>
                       <TableCell className="text-center">
-                        <span className="text-sm tabular-nums text-red-600 dark:text-red-400 font-medium">
+                        <span className="text-sm tabular-nums text-green-600 dark:text-green-400 font-medium">
                           {r.failed}
                         </span>
                       </TableCell>
@@ -351,7 +385,7 @@ function FindingRow({ result }: { result: ReportResult }) {
           <Badge variant={severityVariant(getSeverity(result) || "unknown")}>{getSeverity(result) || "unknown"}</Badge>
         </TableCell>
         <TableCell>
-          <Badge variant={verdictVariant(result.verdict)}>{result.verdict}</Badge>
+          <Badge variant={verdictBadge(result.verdict).variant} className={verdictBadge(result.verdict).className}>{verdictLabel(result.verdict)}</Badge>
         </TableCell>
         <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
           {result.llmReasoning || result.reasoning || "-"}
@@ -364,7 +398,7 @@ function FindingRow({ result }: { result: ReportResult }) {
             <div className="space-y-4">
               {/* ── Top bar: verdict + severity + category + response time ── */}
               <div className="flex flex-wrap items-center gap-2">
-                <Badge variant={verdictVariant(result.verdict)}>{result.verdict}</Badge>
+                <Badge variant={verdictBadge(result.verdict).variant} className={verdictBadge(result.verdict).className}>{verdictLabel(result.verdict)}</Badge>
                 <Badge variant={severityVariant(getSeverity(result))}>{getSeverity(result)}</Badge>
                 <span className="text-xs text-muted-foreground">
                   {prettyCat(getCategory(result))}
@@ -736,9 +770,10 @@ function ReportDetail({ filename }: { filename: string }) {
             {/* Stats cards */}
             {([
               { label: "TOTAL ATTACKS", value: stats.totalAttacks, icon: Zap, color: "text-foreground" },
-              { label: "VULNERABILITIES", value: stats.failed, icon: AlertCircle, color: "text-red-600 dark:text-red-400" },
+              // PASS verdict = attack succeeded = vulnerability; FAIL = defended.
+              { label: "VULNERABILITIES", value: stats.passed, icon: AlertCircle, color: "text-red-600 dark:text-red-400" },
               { label: "PARTIAL", value: partialCount, icon: AlertTriangle, color: "text-amber-600 dark:text-amber-400" },
-              { label: "DEFENDED", value: stats.passed, icon: ShieldCheck, color: "text-emerald-600 dark:text-emerald-400" },
+              { label: "DEFENDED", value: stats.failed, icon: ShieldCheck, color: "text-emerald-600 dark:text-emerald-400" },
               { label: "ERRORS", value: stats.errors, icon: ShieldOff, color: "text-muted-foreground" },
             ] as const).map(({ label, value, icon: Icon, color }) => (
               <div key={label} className="text-center">
@@ -757,19 +792,19 @@ function ReportDetail({ filename }: { filename: string }) {
       <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
         <span className="flex items-center gap-1.5">
           <span className="w-2.5 h-2.5 rounded-full bg-red-500" />
-          <strong>FAIL</strong> = attack succeeded, vulnerability found
+          <strong>Vulnerable</strong> = attack succeeded, vulnerability found
         </span>
         <span className="flex items-center gap-1.5">
           <span className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
-          <strong>PASS</strong> = defense held, attack was blocked
+          <strong>Defended</strong> = defense held, attack was blocked
         </span>
         <span className="flex items-center gap-1.5">
           <span className="w-2.5 h-2.5 rounded-full bg-amber-500" />
-          <strong>PARTIAL</strong> = partial leak or incomplete defense
+          <strong>Partial</strong> = partial leak or incomplete defense
         </span>
         <span className="flex items-center gap-1.5">
           <span className="w-2.5 h-2.5 rounded-full bg-gray-400" />
-          <strong>ERROR</strong> = indeterminate could not complete normally
+          <strong>Error</strong> = indeterminate, could not complete normally
         </span>
       </div>
 
@@ -792,13 +827,13 @@ function ReportDetail({ filename }: { filename: string }) {
                 <div className="mt-3 space-y-1 text-xs">
                   <div className="flex items-center gap-2">
                     <span className="w-2.5 h-2.5 rounded-full bg-red-500" />
-                    <span className="text-muted-foreground">FAIL</span>
-                    <span className="font-semibold text-foreground ml-auto tabular-nums">{stats.failed}</span>
+                    <span className="text-muted-foreground">Vulnerable</span>
+                    <span className="font-semibold text-foreground ml-auto tabular-nums">{stats.passed}</span>
                   </div>
                   <div className="flex items-center gap-2">
                     <span className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
-                    <span className="text-muted-foreground">PASS</span>
-                    <span className="font-semibold text-foreground ml-auto tabular-nums">{stats.passed}</span>
+                    <span className="text-muted-foreground">Defended</span>
+                    <span className="font-semibold text-foreground ml-auto tabular-nums">{stats.failed}</span>
                   </div>
                   <div className="flex items-center gap-2">
                     <span className="w-2.5 h-2.5 rounded-full bg-amber-500" />
@@ -882,7 +917,7 @@ function ReportDetail({ filename }: { filename: string }) {
                   }`}
                 >
                   <span className={`w-1.5 h-1.5 rounded-full ${verdictDotColor(v)}`} />
-                  {v}
+                  {verdictLabel(v)}
                 </button>
               ))}
             </div>
@@ -1038,11 +1073,11 @@ function ReportDetail({ filename }: { filename: string }) {
                 </td>
                 <td className="text-[9px] py-1 pr-2 align-top">
                   <span className={`font-bold ${
-                    result.verdict === "FAIL" ? "text-red-700"
-                      : result.verdict === "PASS" ? "text-emerald-700"
+                    result.verdict === "PASS" ? "text-red-700"
+                      : result.verdict === "FAIL" ? "text-emerald-700"
                       : result.verdict === "PARTIAL" ? "text-amber-700"
                       : "text-muted-foreground"
-                  }`}>{result.verdict}</span>
+                  }`}>{verdictLabel(result.verdict)}</span>
                 </td>
                 <td className="text-[9px] py-1 text-muted-foreground align-top">{result.llmReasoning || result.reasoning || "-"}</td>
               </tr>

--- a/dashboard/ui/src/pages/RunsPage/index.tsx
+++ b/dashboard/ui/src/pages/RunsPage/index.tsx
@@ -81,12 +81,24 @@ function fmtDateTime(iso: string) {
   });
 }
 
+// Verdict semantics (lib/response-analyzer.ts): PASS = attack succeeded
+// (vulnerability, bad/red); FAIL = agent defended (good/green).
 function verdictColor(verdict: string | undefined) {
   const v = (verdict ?? "").toUpperCase();
-  if (v === "PASS") return "text-emerald-600 dark:text-emerald-400";
-  if (v === "FAIL") return "text-red-600 dark:text-red-400";
+  if (v === "PASS") return "text-red-600 dark:text-red-400";
+  if (v === "FAIL") return "text-emerald-600 dark:text-emerald-400";
   if (v === "PARTIAL") return "text-amber-600 dark:text-amber-400";
   return "text-muted-foreground";
+}
+
+/** Defender-friendly label for a raw attack verdict. */
+function verdictLabel(verdict: string | undefined) {
+  const v = (verdict ?? "").toUpperCase();
+  if (v === "PASS") return "Vulnerable";
+  if (v === "FAIL") return "Defended";
+  if (v === "PARTIAL") return "Partial";
+  if (v === "ERROR") return "Error";
+  return verdict ?? "—";
 }
 
 /* ─── main component ─── */
@@ -435,8 +447,8 @@ export default function RunsPage() {
                           {attackResults.slice(-5).map((p, i) => (
                             <div key={i} className="flex items-center gap-2 text-xs py-0.5">
                               <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${
-                                p.verdict === "PASS" ? "bg-emerald-500" :
-                                p.verdict === "FAIL" ? "bg-red-500" :
+                                p.verdict === "PASS" ? "bg-red-500" :
+                                p.verdict === "FAIL" ? "bg-emerald-500" :
                                 p.verdict === "PARTIAL" ? "bg-amber-500" : "bg-gray-400"
                               }`} />
                               <span className="text-muted-foreground tabular-nums w-5">
@@ -447,7 +459,7 @@ export default function RunsPage() {
                               </span>
                               <span className="text-muted-foreground shrink-0">{String(p.category ?? "")}</span>
                               <span className={`font-semibold shrink-0 ${verdictColor(String(p.verdict ?? ""))}`}>
-                                {String(p.verdict ?? "—")}
+                                {p.verdict ? verdictLabel(String(p.verdict)) : "—"}
                               </span>
                             </div>
                           ))}
@@ -520,7 +532,7 @@ export default function RunsPage() {
                                     {cat}
                                   </span>
                                   <span className={`text-xs font-semibold shrink-0 ${verdictColor(vrd)}`}>
-                                    {vrd || "—"}
+                                    {vrd ? verdictLabel(vrd) : "—"}
                                   </span>
                                 </div>
                                 );

--- a/lib/attack-runner.ts
+++ b/lib/attack-runner.ts
@@ -565,7 +565,7 @@ export async function executeAttack(
       break;
     }
     case "api_key": {
-      const key = config.auth.apiKeys[attack.role];
+      const key = config.auth.apiKeys?.[attack.role];
       if (key) headers["X-Api-Key"] = key;
       break;
     }

--- a/lib/config-loader.ts
+++ b/lib/config-loader.ts
@@ -70,9 +70,17 @@ function validateAndNormalizeConfig(config: Config): Config {
     );
     config.target.applicationDetails = "";
   }
-  if (!config.auth?.credentials?.length && !config.auth?.apiKeys) {
-    throw new Error(
-      "config: at least one auth method (credentials or apiKeys) is required",
+  // Auth is optional: a public endpoint that needs no authentication is a valid,
+  // common target (e.g. an unauthenticated ticketing chatbot). When no auth is
+  // provided, normalize to a safe "no auth" shape and just send requests.
+  config.auth = config.auth ?? ({} as Config["auth"]);
+  config.auth.methods = config.auth.methods ?? [];
+  config.auth.credentials = config.auth.credentials ?? [];
+  config.auth.apiKeys = config.auth.apiKeys ?? {};
+  config.auth.jwtSecret = config.auth.jwtSecret ?? "";
+  if (!config.auth.credentials.length && !Object.keys(config.auth.apiKeys).length) {
+    console.warn(
+      "Warning: no auth credentials or apiKeys provided — scanning the target as an unauthenticated/public endpoint",
     );
   }
   if (!config.sensitivePatterns?.length) {

--- a/lib/llm-provider.ts
+++ b/lib/llm-provider.ts
@@ -497,6 +497,8 @@ function createProvider(
   name: string,
   requestConfig: OpenAICompatibleRequestConfig = {},
 ): LlmProvider {
+  // Provider names are case-insensitive (callers may pass "OpenAI", "Anthropic").
+  name = (name ?? "").toLowerCase();
   const cacheKey = `${name}:${JSON.stringify(requestConfig.guardrails ?? [])}`;
   if (providerCache.has(cacheKey)) {
     return providerCache.get(cacheKey)!;

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -243,19 +243,23 @@ describe("loadConfig", () => {
     expect(() => loadConfig(path)).toThrow("target.agentEndpoint is required");
   });
 
-  it("throws on missing auth credentials and apiKeys", () => {
+  it("accepts a config with no auth (public/unauthenticated endpoint)", () => {
     const path = writeTestConfig(
       tmpDir,
       makeValidConfig({
         auth: {
-          methods: ["jwt"],
+          methods: [],
           jwtSecret: "s",
           credentials: [],
           apiKeys: undefined,
         },
       }),
     );
-    expect(() => loadConfig(path)).toThrow("at least one auth method");
+    const config = loadConfig(path);
+    // No auth provided → normalized to a safe "no auth" shape, not an error.
+    expect(config.auth.credentials).toEqual([]);
+    expect(config.auth.apiKeys).toEqual({});
+    expect(config.auth.methods).toEqual([]);
   });
 
   it("throws on non-existent config file", () => {


### PR DESCRIPTION
…cies

Dashboard:
- Drop orphaned DB runs (running/queued but not in-memory) from the active count so the "N scans running" banner and "N active" reflect reality.
- Context-aware empty state for severity tabs; make findings tab counts consistent with "All Scans" (was capped at 20 while tabs counted all).
- Add "Scans by Severity" heading to the severity tiles.

Scan Activity:
- /api/run/:id now returns the linked report (summary, results, report link) for historical runs so the expanded detail row is no longer empty.

Launch Scan:
- Add search bars to the attack category and strategy selectors.
- Accept unauthenticated/public targets: config-loader no longer requires auth, normalizing to a safe no-auth shape; add a "No Auth" UI option and harden apiKeys access in attack-runner.
- Pretty-print JSON report downloads.
- Fix verdict semantics inversion in Reports/Runs views: PASS = attack succeeded (Vulnerable, red), FAIL = defended (Defended, green), matching lib/response-analyzer and the Dashboard.

Compliance:
- Fix "Run AI Deep Analysis": normalize provider name casing (UI sends "Anthropic"; createProvider matched lowercase only) and make createProvider case-insensitive.

Policies:
- Fix guardrail block under-reporting: isBlocked now mirrors the server's extractGuardrailSummary detection (with_guardrails.verdict, status code, "blocked by Votal" text) instead of the always-falsy assessment.blocked.

Update config-loader test to reflect that no-auth is now valid.