### PR TITLE
docs: restructure navigation into sections + Votal-branded theme

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ baseurl: ""
 remote_theme: just-the-docs/just-the-docs
 
 # Sidebar logo
-logo: "/assets/votalai-logo.png"
+logo: "/assets/votalai-logo.svg"
 
 plugins:
   - jekyll-remote-theme
@@ -30,8 +30,8 @@ aux_links:
 
 aux_links_new_tab: true
 
-# Color scheme
-color_scheme: light
+# Color scheme (Votal AI brand — see _sass/color_schemes/votal.scss)
+color_scheme: votal
 
 # Heading anchor links
 heading_anchors: true

--- a/docs/_sass/color_schemes/votal.scss
+++ b/docs/_sass/color_schemes/votal.scss
@@ -1,0 +1,9 @@
+// Votal AI brand color scheme for Just the Docs (extends the light scheme).
+@import "./light";
+
+$link-color: #4f46e5;          // indigo-600
+$btn-primary-color: #4f46e5;
+$nav-child-link-color: #4a4861;
+
+// Search + selected nav accents
+$search-result-preview-color: #6b7280;

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,108 @@
+// ── Votal AI docs — custom styling ──────────────────────────────────────────
+
+// Brand tokens
+$votal-indigo: #4f46e5;
+$votal-indigo-dark: #4338ca;
+$votal-ink: #1e1b3a;
+
+// Sidebar logo sizing
+.site-logo {
+  height: 2rem;
+  background-size: contain;
+  background-position: left center;
+}
+
+// ── Landing hero ────────────────────────────────────────────────────────────
+.hero-badge {
+  display: inline-block;
+  padding: 0.3rem 0.8rem;
+  margin-bottom: 1rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.1);
+  color: $votal-indigo;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.hero-title {
+  font-size: 2.6rem;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.hero-subtitle {
+  font-size: 1.1rem;
+  font-weight: 300;
+  color: #4a4861;
+  max-width: 42rem;
+}
+
+// ── Stats row ───────────────────────────────────────────────────────────────
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.5rem;
+  margin: 2.5rem 0;
+  padding: 1.5rem 0;
+  border-top: 1px solid #ececf2;
+  border-bottom: 1px solid #ececf2;
+  text-align: center;
+}
+
+.stat-num {
+  font-size: 2rem;
+  font-weight: 700;
+  color: $votal-ink;
+  letter-spacing: -0.02em;
+}
+
+.stat-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-top: 0.25rem;
+}
+
+// ── Feature cards ───────────────────────────────────────────────────────────
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0 2.5rem;
+}
+
+.feature-card {
+  border: 1px solid #ececf2;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.feature-card:hover {
+  border-color: rgba(79, 70, 229, 0.4);
+  box-shadow: 0 4px 16px rgba(30, 27, 58, 0.06);
+}
+
+.feature-card h3 {
+  margin-top: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.feature-card p {
+  margin-bottom: 0;
+  font-size: 0.88rem;
+  color: #4a4861;
+}
+
+.feature-icon {
+  font-size: 1.4rem;
+  display: block;
+  margin-bottom: 0.5rem;
+}

--- a/docs/api-only.md
+++ b/docs/api-only.md
@@ -1,6 +1,7 @@
 ---
 title: API-Only Testing
-nav_order: 5
+parent: Get Started
+nav_order: 4
 ---
 
 # API-Only (Black-Box) Testing

--- a/docs/assets/votalai-logo.svg
+++ b/docs/assets/votalai-logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 168 32" width="168" height="32" role="img" aria-label="VotalAI">
+  <defs>
+    <linearGradient id="vshield" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6366f1"/>
+      <stop offset="1" stop-color="#4338ca"/>
+    </linearGradient>
+  </defs>
+  <!-- shield mark -->
+  <path d="M16 2.5l10 3.4v7.2c0 6.6-4.2 11.4-10 13.4-5.8-2-10-6.8-10-13.4V5.9z" fill="url(#vshield)"/>
+  <path d="M11 13.5l3.6 4.2L21.5 10" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- wordmark -->
+  <text x="36" y="22" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="-0.3" fill="#1e1b3a">Votal<tspan fill="#4f46e5">AI</tspan></text>
+</svg>

--- a/docs/attack-catalog.md
+++ b/docs/attack-catalog.md
@@ -1,6 +1,7 @@
 ---
 title: Attack Catalog
-nav_order: 6
+parent: Attacks & Analysis
+nav_order: 1
 ---
 
 # Attack Catalog

--- a/docs/attacks.md
+++ b/docs/attacks.md
@@ -1,0 +1,16 @@
+---
+title: Attacks & Analysis
+nav_order: 3
+has_children: true
+---
+
+# Attacks & Analysis
+{: .no_toc }
+
+How attacks are generated, escalated, judged, and mapped to compliance frameworks.
+
+- **[Attack Catalog]({{ site.baseurl }}/attack-catalog/)** — the full catalog of attack categories.
+- **[Multi-Turn Attacks]({{ site.baseurl }}/multi-turn/)** — crescendo and multi-step conversation escalation.
+- **[Playbook & Analysis]({{ site.baseurl }}/playbook/)** — reading results and prioritizing findings.
+- **[Judge Evaluation Prompt]({{ site.baseurl }}/judge-evaluation-prompt/)** — the exact LLM-judge prompt and verdict policy.
+- **[Compliance Frameworks]({{ site.baseurl }}/compliance/)** — map findings to OWASP, NIST, and more.

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,6 +1,7 @@
 ---
 title: CI/CD Integration
-nav_order: 19
+parent: Deploy & Operate
+nav_order: 3
 ---
 
 # CI/CD Integration

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,6 +1,7 @@
 ---
 title: Comparison & Status
-nav_order: 17
+parent: Reference
+nav_order: 1
 ---
 
 # Comparison vs Other Tools

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,6 +1,7 @@
 ---
 title: Compliance Frameworks
-nav_order: 10
+parent: Attacks & Analysis
+nav_order: 5
 ---
 
 # Compliance Frameworks

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,7 @@
 ---
 title: Configuration
-nav_order: 3
+parent: Get Started
+nav_order: 2
 ---
 
 # Configuration Reference

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,7 @@
 ---
 title: Contributing
-nav_order: 15
+parent: Reference
+nav_order: 3
 ---
 
 # Contributing

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,6 +1,7 @@
 ---
 title: Dashboard
-nav_order: 11
+parent: Deploy & Operate
+nav_order: 2
 ---
 
 # Dashboard

--- a/docs/deploy-operate.md
+++ b/docs/deploy-operate.md
@@ -1,0 +1,15 @@
+---
+title: Deploy & Operate
+nav_order: 6
+has_children: true
+---
+
+# Deploy & Operate
+{: .no_toc }
+
+Run the dashboard, ship to your environment, and operate it safely.
+
+- **[Deployment]({{ site.baseurl }}/deployment/)** — deploy the scanner and dashboard.
+- **[Dashboard]({{ site.baseurl }}/dashboard/)** — the web UI for scans, reports, and policies.
+- **[CI/CD Integration]({{ site.baseurl }}/cicd/)** — gate pull requests on scan results.
+- **[Operations & Security]({{ site.baseurl }}/operations/)** — hardening, secrets, and runtime concerns.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,7 @@
 ---
 title: Deployment
-nav_order: 12
+parent: Deploy & Operate
+nav_order: 1
 ---
 
 # Docker & Deployment

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,0 +1,15 @@
+---
+title: Develop
+nav_order: 4
+has_children: true
+---
+
+# Develop
+{: .no_toc }
+
+Extend the scanner, wire in your own providers, and call it from code.
+
+- **[LLM Providers]({{ site.baseurl }}/providers/)** — supported attack and judge providers.
+- **[APIs & SDKs]({{ site.baseurl }}/sdk-integrations/)** — drive scans programmatically.
+- **[Developer Tools]({{ site.baseurl }}/developer-tools/)** — CLIs and helpers for local work.
+- **[Extending]({{ site.baseurl }}/extending/)** — add custom attacks, strategies, and policies.

--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -1,6 +1,7 @@
 ---
 title: Developer Tools
-nav_order: 14
+parent: Develop
+nav_order: 3
 ---
 
 # Developer Tools & Agent Integration

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,6 +1,7 @@
 ---
 title: Extending
-nav_order: 13
+parent: Develop
+nav_order: 4
 ---
 
 # Extending the Framework

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,7 @@
 ---
 title: FAQ for Evaluators
-nav_order: 18
+parent: Reference
+nav_order: 2
 ---
 
 # FAQ for Evaluators

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,15 @@
+---
+title: Get Started
+nav_order: 2
+has_children: true
+---
+
+# Get Started
+{: .no_toc }
+
+Everything you need to run your first scan and tailor it to your stack.
+
+- **[Quick Start]({{ site.baseurl }}/quick-start/)** — install, configure, and run your first scan in minutes.
+- **[Configuration]({{ site.baseurl }}/configuration/)** — targets, auth, and scan options explained.
+- **[White-Box Scanning]({{ site.baseurl }}/white-box/)** — point it at your source code for stack-specific attacks.
+- **[API-Only Testing]({{ site.baseurl }}/api-only/)** — black-box mode for endpoints you don't have source for.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,46 @@ description: White-box red teaming for agentic AI apps. Reads your code, finds b
 permalink: /
 ---
 
-# Red-Team AI
+<span class="hero-badge">White-Box AI Red Teaming</span>
 
-White-box red teaming for agentic AI apps. Reads your code, finds bugs specific to your stack — not generic prompt injections.
-{: .fs-6 .fw-300 }
+<h1 class="hero-title">Red-Team AI</h1>
+
+<p class="hero-subtitle">White-box red teaming for agentic AI apps. It reads your application's source code first — learning your tools, roles, and guardrails — then generates attacks tailored to <em>your</em> stack, not generic prompt injections.</p>
 
 [Get started]({{ site.baseurl }}/quick-start/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/sundi133/wb-red-team){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+<div class="stat-grid">
+  <div><div class="stat-num">141</div><div class="stat-label">Attack Categories</div></div>
+  <div><div class="stat-num">155</div><div class="stat-label">Attack Strategies</div></div>
+  <div><div class="stat-num">11</div><div class="stat-label">Compliance Frameworks</div></div>
+  <div><div class="stat-num">15</div><div class="stat-label">Max Conversation Turns</div></div>
+</div>
+
+## Why Red-Team AI
+
+<div class="feature-grid">
+  <div class="feature-card">
+    <span class="feature-icon">🔍</span>
+    <h3>White-box analysis</h3>
+    <p>Scans your codebase for tools, roles, guardrails, auth methods, and sensitive literals before a single attack is sent.</p>
+  </div>
+  <div class="feature-card">
+    <span class="feature-icon">🧠</span>
+    <h3>LLM-driven planning</h3>
+    <p>Combines 141 categories with 155 strategies and prioritizes the attacks your codebase suggests will actually work.</p>
+  </div>
+  <div class="feature-card">
+    <span class="feature-icon">🔁</span>
+    <h3>Adaptive multi-round</h3>
+    <p>Each round doubles down on near-misses from the last, with crescendo multi-turn escalation up to 15 turns.</p>
+  </div>
+  <div class="feature-card">
+    <span class="feature-icon">⚖️</span>
+    <h3>Policy-driven judging</h3>
+    <p>Every response is judged by an LLM against configurable policy and mapped to 11 compliance frameworks.</p>
+  </div>
+</div>
 
 ---
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: Integrations
-nav_order: 7
+nav_order: 5
 has_children: true
 ---
 

--- a/docs/judge-evaluation-prompt.md
+++ b/docs/judge-evaluation-prompt.md
@@ -1,3 +1,9 @@
+---
+title: Judge Evaluation Prompt
+parent: Attacks & Analysis
+nav_order: 4
+---
+
 # Judge Evaluation Prompt
 
 This is the full prompt sent to the LLM judge (default: Claude Sonnet) for each attack verdict evaluation. All variables have been resolved using the Default Security Policy.

--- a/docs/multi-turn.md
+++ b/docs/multi-turn.md
@@ -1,6 +1,7 @@
 ---
 title: Multi-Turn Attacks
-nav_order: 7
+parent: Attacks & Analysis
+nav_order: 2
 ---
 
 # Multi-Turn Attacks

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,6 +1,7 @@
 ---
 title: Operations & Security
-nav_order: 16
+parent: Deploy & Operate
+nav_order: 4
 ---
 
 # Troubleshooting & Security

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -1,6 +1,7 @@
 ---
 title: Playbook & Analysis
-nav_order: 8
+parent: Attacks & Analysis
+nav_order: 3
 ---
 
 # Attack Design Playbook & Result Analysis

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,7 @@
 ---
 title: LLM Providers
-nav_order: 9
+parent: Develop
+nav_order: 1
 ---
 
 # LLM Providers

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,6 +1,7 @@
 ---
 title: Quick Start
-nav_order: 2
+parent: Get Started
+nav_order: 1
 ---
 
 # Quick Start

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,14 @@
+---
+title: Reference
+nav_order: 7
+has_children: true
+---
+
+# Reference
+{: .no_toc }
+
+Background, comparisons, and contribution guidance.
+
+- **[Comparison & Status]({{ site.baseurl }}/comparison/)** — how this compares to other tools.
+- **[FAQ for Evaluators]({{ site.baseurl }}/faq/)** — common questions answered.
+- **[Contributing]({{ site.baseurl }}/contributing/)** — how to contribute.

--- a/docs/sdk-integrations.md
+++ b/docs/sdk-integrations.md
@@ -1,6 +1,7 @@
 ---
 title: APIs & SDKs
-nav_order: 6
+parent: Develop
+nav_order: 2
 ---
 
 # APIs & SDKs

--- a/docs/white-box.md
+++ b/docs/white-box.md
@@ -1,6 +1,7 @@
 ---
 title: White-Box Scanning
-nav_order: 4
+parent: Get Started
+nav_order: 3
 ---
 
 # White-Box Scanning


### PR DESCRIPTION
Navigation:
- Group the flat 19-item sidebar into 6 collapsible sections (Get Started, Attacks & Analysis, Develop, Integrations, Deploy & Operate, Reference) using the Just-the-Docs parent/child pattern; add a landing page per section.
- Add missing front matter to judge-evaluation-prompt.md (was untitled/broken in the nav) and fix duplicate nav_order values. No page content changed — only front matter rearranged.

Theme:
- Add Votal brand color scheme (_sass/color_schemes/votal.scss, indigo accent) and custom styles (_sass/custom/custom.scss) for hero, stats, feature cards.
- Rebuild the landing page hero with badge, stats row, and feature-card grid while keeping the product name and all existing content.
- Fix broken sidebar logo: _config.yml referenced a non-existent votalai-logo.png; add an SVG logo and point to it.