### PR TITLE
docs: fix Pages build (unresolvable ./light SCSS import)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,8 +30,8 @@ aux_links:
 
 aux_links_new_tab: true
 
-# Color scheme (Votal AI brand — see _sass/color_schemes/votal.scss)
-color_scheme: votal
+# Color scheme — built-in light; Votal indigo accent applied in _sass/custom/custom.scss
+color_scheme: light
 
 # Heading anchor links
 heading_anchors: true

--- a/docs/_sass/color_schemes/votal.scss
+++ b/docs/_sass/color_schemes/votal.scss
@@ -1,9 +1,0 @@
-// Votal AI brand color scheme for Just the Docs (extends the light scheme).
-@import "./light";
-
-$link-color: #4f46e5;          // indigo-600
-$btn-primary-color: #4f46e5;
-$nav-child-link-color: #4a4861;
-
-// Search + selected nav accents
-$search-result-preview-color: #6b7280;

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -5,6 +5,28 @@ $votal-indigo: #4f46e5;
 $votal-indigo-dark: #4338ca;
 $votal-ink: #1e1b3a;
 
+// ── Votal indigo accent ─────────────────────────────────────────────────────
+// Applied as plain overrides on top of the built-in light scheme. (A custom
+// color_scheme that @imports "./light" fails on GitHub Pages remote themes,
+// so the brand accent lives here instead.)
+.btn-primary {
+  background-color: $votal-indigo;
+  background-image: none;
+  border-color: $votal-indigo;
+}
+.btn-primary:hover {
+  background-color: $votal-indigo-dark;
+  border-color: $votal-indigo-dark;
+}
+
+.main-content a {
+  color: $votal-indigo;
+}
+
+.site-nav .nav-list-item .nav-list-link.active {
+  color: $votal-indigo;
+}
+
 // Sidebar logo sizing
 .site-logo {
   height: 2rem;


### PR DESCRIPTION
## Problem
The Pages build on `main` is **failing** (run 28417973536), so docs.cart.votal.ai is stuck on the pre-revamp version.

```
docs/_sass/color_schemes/votal.scss:2: File to import not found or unreadable: ./light. (Sass::SyntaxError)
```

With a **remote theme**, the site's local `_sass/color_schemes/` (which only contained `votal.scss`) shadows the theme's, so the custom scheme's `@import "./light"` resolves to nothing.

## Fix
- Remove `_sass/color_schemes/votal.scss` and revert to the built-in `color_scheme: light` (the value the site used before, known to build).
- Move the Votal indigo accent (primary buttons, content links, active nav link) into `_sass/custom/custom.scss`, which is always imported and has no fragile imports.

No navigation or content changes — the section restructure and landing page from #252 are untouched. `custom.scss` compiles cleanly with dart-sass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)