### PR TITLE
dashboard: extract agent text from structured responseBody

### DIFF
--- a/dashboard/ui/src/api/types.ts
+++ b/dashboard/ui/src/api/types.ts
@@ -66,7 +66,9 @@ export interface ReportResult {
     severity_override?: string | null;
   };
   payload?: string;
-  responseBody?: string;
+  // The captured agent response. Often a string, but many targets return a
+  // structured body like { response, tool_calls, user, ... } or { error, ... }.
+  responseBody?: string | Record<string, unknown>;
   findings?: string[];
   steps?: ConversationStep[];
   conversation?: ConversationStep[];

--- a/dashboard/ui/src/pages/ReportsPage/index.tsx
+++ b/dashboard/ui/src/pages/ReportsPage/index.tsx
@@ -343,6 +343,34 @@ function ExpandableText({ text, maxLines = 4 }: { text: string; maxLines?: numbe
   );
 }
 
+/**
+ * Extract human-readable response text from a captured agent response body,
+ * which may be a plain string OR a structured object like
+ * `{ response, tool_calls, user, ... }` or `{ error, riskLevel, ... }`.
+ * Returns "" when there's nothing meaningful to show.
+ */
+function extractResponseText(rb: unknown): string {
+  if (rb == null) return "";
+  if (typeof rb === "string") return rb;
+  if (typeof rb !== "object") return String(rb);
+  const o = rb as Record<string, unknown>;
+  // The agent's textual answer (target responsePath is typically "response").
+  for (const k of ["response", "content", "text", "message", "answer", "output", "reply"]) {
+    const v = o[k];
+    if (typeof v === "string" && v.trim()) return v;
+  }
+  // Guardrail-blocked / error bodies — surface the error message.
+  if (typeof o.error === "string" && o.error.trim()) return o.error;
+  // Nothing useful (e.g. empty object) — signal "no text".
+  if (Object.keys(o).length === 0) return "";
+  // Fallback: show the raw body so nothing is silently dropped.
+  try {
+    return JSON.stringify(rb, null, 2);
+  } catch {
+    return String(rb);
+  }
+}
+
 /* ─── Finding Row (rich expandable detail) ─── */
 
 function FindingRow({ result }: { result: ReportResult }) {
@@ -365,9 +393,10 @@ function FindingRow({ result }: { result: ReportResult }) {
   const lastAgentTurn = [...conversations]
     .reverse()
     .find((s) => s.role && s.role !== "user" && (s.content ?? "").trim());
-  const responseText = result.responseBody
-    ? (typeof result.responseBody === "string" ? result.responseBody : JSON.stringify(result.responseBody, null, 2))
-    : (lastAgentTurn?.content ?? "");
+  // responseBody may be a string or a structured object ({ response, ... });
+  // extract the agent's text either way, then fall back to the last agent turn.
+  const responseText =
+    extractResponseText(result.responseBody) || (lastAgentTurn?.content ?? "");
   // Whether this row represents an actual HTTP interaction (so a Response panel
   // belongs even when there's no text — vs. static/codebase findings).
   const hasInteraction =


### PR DESCRIPTION
Many targets return a structured response body, e.g.
  "responseBody": { "response": "I don't have real access...", "tool_calls": [], "user": {...} }
or a guardrail-blocked body { "error": "Request blocked by input guardrail", ... }. The UI only handled string bodies (dumping objects as raw JSON), so the agent's actual reply appeared to be missing.

- Add extractResponseText(): pulls the text from response/content/text/message/ answer/output/reply, falls back to the error field, then to pretty JSON.
- Widen ReportResult.responseBody type to string | object to match reality.