### PR TITLE
dashboard: connect MCP & WebSocket targets from Launch Scan form

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -1,7 +1,7 @@
 import { bootstrapProxy } from "../lib/proxy-bootstrap.js";
 bootstrapProxy();
 
-import { createServer, type IncomingMessage } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import {
   readFileSync,
   readdirSync,
@@ -17,6 +17,7 @@ import { execSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { loadConfig } from "../lib/config-loader.js";
 import { loadConfigFromObject } from "../lib/config-loader.js";
+import { discoverMcpSurface } from "../lib/mcp/discovery.js";
 import { loadEnvFile } from "../lib/env-loader.js";
 import {
   getJudgeProvider,
@@ -472,6 +473,37 @@ function getJobStatus(job: Job): Job["status"] {
 const jobs = new Map<string, Job>();
 let activeRuns = 0;
 const MAX_CONCURRENT = parseInt(process.env.MAX_CONCURRENT_RUNS || "100", 10);
+
+/**
+ * MCP "stdio" transport spawns an arbitrary local process on THIS server, so it
+ * must never be reachable by untrusted users on a shared/hosted instance.
+ * It stays disabled unless a deployment explicitly opts in (self-hosted/on-prem).
+ * The CLI (tsx red-team.ts) is unaffected — this only gates the dashboard API.
+ */
+function mcpStdioAllowed(): boolean {
+  const v = (process.env.ALLOW_MCP_STDIO || "").toLowerCase();
+  return v === "true" || v === "1" || v === "yes";
+}
+
+/** Reject an MCP stdio target unless this instance allows it. Returns true if handled (rejected). */
+function rejectMcpStdioIfDisabled(config: Config, res: ServerResponse): boolean {
+  if (
+    config.target.type === "mcp" &&
+    config.target.mcp?.transport === "stdio" &&
+    !mcpStdioAllowed()
+  ) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        error: "MCP stdio transport is disabled on this instance",
+        detail:
+          "Stdio runs a local process on the server and is only available on self-hosted deployments (set ALLOW_MCP_STDIO=true). Use a remote MCP server over Streamable HTTP instead.",
+      }),
+    );
+    return true;
+  }
+  return false;
+}
 
 // ── Run config persistence (file-based fallback when no DB) ──
 const RUN_CONFIGS_PATH = join(
@@ -1073,6 +1105,10 @@ const server = createServer(
           return;
         }
 
+        // Safety gate: never run an MCP stdio target (arbitrary local process)
+        // on a shared instance unless explicitly enabled.
+        if (rejectMcpStdioIfDisabled(config, res)) return;
+
         const job = enqueueJob(config, ctx);
         if (ctx) {
           await logAudit(ctx, "run.start", "run", job.id, {
@@ -1103,6 +1139,66 @@ const server = createServer(
             detail: formatErrorDetails(err),
           }),
         );
+      }
+      return;
+    }
+
+    // POST /api/mcp-discover — connect to an MCP target and list its surface
+    // (tools / prompts / resources) so users can verify the connection before scanning.
+    if (url.pathname === "/api/mcp-discover" && req.method === "POST") {
+      const clientIp =
+        req.headers["x-forwarded-for"]?.toString().split(",")[0].trim() ||
+        req.socket.remoteAddress ||
+        "unknown";
+      const { allowed, retryAfterSec } = checkApiRateLimit(clientIp, "mcp-discover");
+      if (!allowed) {
+        res.writeHead(429, { "Content-Type": "application/json", "Retry-After": String(retryAfterSec) });
+        res.end(JSON.stringify({ error: "Too many requests. Please try again later.", retryAfterSec }));
+        return;
+      }
+      let config: Config;
+      try {
+        config = loadConfigFromObject(JSON.parse(await readBody(req)));
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid configuration", detail: formatErrorDetails(err) }));
+        return;
+      }
+      if (config.target.type !== "mcp" || !config.target.mcp) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Target is not an MCP server" }));
+        return;
+      }
+      // Same safety gate as runs — discovery also spawns the stdio process.
+      if (rejectMcpStdioIfDisabled(config, res)) return;
+
+      try {
+        // Bound the attempt so an unreachable/hung server can't hold the socket open.
+        const DISCOVER_TIMEOUT_MS = 25_000;
+        const d = await Promise.race([
+          discoverMcpSurface(config),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("Connection timed out")), DISCOVER_TIMEOUT_MS),
+          ),
+        ]);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            ok: true,
+            transport: d.transport,
+            serverInfo: d.serverInfo ?? null,
+            protocolVersion: d.protocolVersion ?? null,
+            capabilities: d.capabilities,
+            tools: d.tools.map((t) => ({ name: t.name, description: t.description ?? "" })),
+            prompts: d.prompts.map((p) => ({ name: p.name, description: p.description ?? "" })),
+            resources: d.resources.map((r) => ({ name: r.name ?? r.uri, uri: r.uri })),
+          }),
+        );
+      } catch (err) {
+        // Connection/timeout failures are an expected user-facing outcome — return
+        // 200 with ok:false so the form can show the message inline.
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: formatErrorDetails(err) }));
       }
       return;
     }
@@ -2512,6 +2608,8 @@ Be specific and factual. Reference real incidents and realistic financial figure
               name: fw.name,
               controlCount: fw.items.length,
             })),
+            // Capability flags for the scan form.
+            allowMcpStdio: mcpStdioAllowed(),
           }),
         );
       } catch (err) {

--- a/dashboard/ui/src/api/reference.ts
+++ b/dashboard/ui/src/api/reference.ts
@@ -1,6 +1,14 @@
 import { apiFetch } from "./client";
-import type { ReferenceData } from "./types";
+import type { ReferenceData, McpDiscoverResult } from "./types";
 
 export function getReference() {
   return apiFetch<ReferenceData>("/api/reference");
+}
+
+/** Connect to an MCP target and list its tools/prompts/resources. */
+export function discoverMcp(config: Record<string, unknown>) {
+  return apiFetch<McpDiscoverResult>("/api/mcp-discover", {
+    method: "POST",
+    body: JSON.stringify(config),
+  });
 }

--- a/dashboard/ui/src/api/types.ts
+++ b/dashboard/ui/src/api/types.ts
@@ -285,6 +285,20 @@ export interface ReferenceData {
   strategies: StrategyInfo[];
   categoryCompliance: Record<string, string[]>;
   frameworks?: { name: string; items: unknown[] }[];
+  /** Whether this instance permits MCP stdio targets (self-hosted only). */
+  allowMcpStdio?: boolean;
+}
+
+export interface McpDiscoverResult {
+  ok: boolean;
+  error?: string;
+  transport?: string;
+  serverInfo?: { name: string; version?: string } | null;
+  protocolVersion?: string | null;
+  capabilities?: string[];
+  tools?: { name: string; description: string }[];
+  prompts?: { name: string; description: string }[];
+  resources?: { name: string; uri: string }[];
 }
 
 export interface StrategyInfo {

--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -216,6 +216,20 @@ export default function NewScanPage() {
   const [authEndpoint, setAuthEndpoint] = useState("");
   const [applicationDetails, setApplicationDetails] = useState("");
 
+  // ── MCP target (when targetType === "mcp") ──
+  const [mcpTransport, setMcpTransport] = useState<"streamable_http" | "stdio">("streamable_http");
+  const [mcpUrl, setMcpUrl] = useState("");
+  const [mcpCommand, setMcpCommand] = useState("");
+  const [mcpArgs, setMcpArgs] = useState(""); // whitespace-separated
+  const [mcpHeaders, setMcpHeaders] = useState<{ key: string; value: string }[]>([{ key: "", value: "" }]);
+  const [mcpAllowlist, setMcpAllowlist] = useState(""); // comma/newline-separated tool names
+  const [mcpDenylist, setMcpDenylist] = useState("");
+
+  // ── WebSocket target (when targetType === "websocket_agent") ──
+  const [wsPath, setWsPath] = useState("/ws/chat");
+  const [wsToken, setWsToken] = useState("");
+  const [wsSubprotocols, setWsSubprotocols] = useState(""); // comma-separated
+
   // ── Auth ──
   const [authMethods, setAuthMethods] = useState<string[]>(["api_key"]);
   const [apiKeys, setApiKeys] = useState<{ role: string; key: string }[]>([
@@ -307,6 +321,31 @@ export default function NewScanPage() {
     if (target?.authEndpoint) setAuthEndpoint(String(target.authEndpoint));
     if (target?.applicationDetails) setApplicationDetails(String(target.applicationDetails));
     if (target?.type) setTargetType(target.type as "http_agent" | "mcp" | "websocket_agent");
+
+    // MCP target
+    const mcp = target?.mcp as Record<string, unknown> | undefined;
+    if (mcp) {
+      if (mcp.transport === "stdio" || mcp.transport === "streamable_http") {
+        setMcpTransport(mcp.transport);
+      }
+      if (mcp.url) setMcpUrl(String(mcp.url));
+      if (mcp.command) setMcpCommand(String(mcp.command));
+      if (Array.isArray(mcp.args)) setMcpArgs((mcp.args as string[]).join(" "));
+      if (mcp.headers && typeof mcp.headers === "object") {
+        const hs = Object.entries(mcp.headers as Record<string, string>).map(([key, value]) => ({ key, value }));
+        if (hs.length > 0) setMcpHeaders(hs);
+      }
+      if (Array.isArray(mcp.allowlistedTools)) setMcpAllowlist((mcp.allowlistedTools as string[]).join(", "));
+      if (Array.isArray(mcp.denylistedTools)) setMcpDenylist((mcp.denylistedTools as string[]).join(", "));
+    }
+
+    // WebSocket target
+    const ws = target?.websocket as Record<string, unknown> | undefined;
+    if (ws) {
+      if (ws.path) setWsPath(String(ws.path));
+      if (ws.token) setWsToken(String(ws.token));
+      if (Array.isArray(ws.subprotocols)) setWsSubprotocols((ws.subprotocols as string[]).join(", "));
+    }
 
     // Auth
     if (auth?.methods && Array.isArray(auth.methods)) setAuthMethods(auth.methods as string[]);
@@ -417,14 +456,60 @@ export default function NewScanPage() {
       if (role && key) apiKeysObj[role] = key;
     });
 
-    const config: Record<string, unknown> = {
-      target: {
-        type: targetType,
+    const splitList = (s: string) =>
+      s.split(/[\n,]/).map((x) => x.trim()).filter(Boolean);
+
+    // Build the target block per target type.
+    let target: Record<string, unknown>;
+    if (targetType === "mcp") {
+      const headersObj: Record<string, string> = {};
+      mcpHeaders.forEach(({ key, value }) => {
+        if (key && value) headersObj[key] = value;
+      });
+      const allow = splitList(mcpAllowlist);
+      const deny = splitList(mcpDenylist);
+      target = {
+        type: "mcp",
+        applicationDetails: applicationDetails || "",
+        mcp: {
+          transport: mcpTransport,
+          ...(mcpTransport === "streamable_http"
+            ? {
+                url: mcpUrl,
+                ...(Object.keys(headersObj).length > 0 ? { headers: headersObj } : {}),
+              }
+            : {
+                command: mcpCommand,
+                ...(mcpArgs.trim() ? { args: mcpArgs.trim().split(/\s+/) } : {}),
+              }),
+          ...(allow.length > 0 ? { allowlistedTools: allow } : {}),
+          ...(deny.length > 0 ? { denylistedTools: deny } : {}),
+        },
+      };
+    } else if (targetType === "websocket_agent") {
+      const subs = splitList(wsSubprotocols);
+      target = {
+        type: "websocket_agent",
+        baseUrl,
+        applicationDetails: applicationDetails || "",
+        websocket: {
+          path: wsPath,
+          ...(subs.length > 0 ? { subprotocols: subs } : {}),
+          ...(wsToken ? { token: wsToken } : {}),
+        },
+      };
+    } else {
+      target = {
+        type: "http_agent",
         baseUrl,
         agentEndpoint,
         authEndpoint: authEndpoint || "",
         applicationDetails: applicationDetails || "",
-      },
+      };
+    }
+
+    const config: Record<string, unknown> = {
+      target,
       auth: {
         methods: authMethods,
         ...(Object.keys(apiKeysObj).length > 0 ? { apiKeys: apiKeysObj } : {}),
@@ -482,14 +567,28 @@ export default function NewScanPage() {
     return config;
   };
 
+  // Whether the minimum required target field for the chosen type is filled.
+  const targetReady =
+    (showJsonOverride && jsonConfig.trim().length > 0) ||
+    (targetType === "mcp"
+      ? mcpTransport === "streamable_http"
+        ? mcpUrl.trim().length > 0
+        : mcpCommand.trim().length > 0
+      : baseUrl.trim().length > 0);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
     setSuccess(null);
 
-    // baseUrl is required unless using JSON override with a target already set
-    if (!baseUrl.trim() && !(showJsonOverride && jsonConfig.trim())) {
-      setError("Target base URL is required.");
+    if (!targetReady) {
+      setError(
+        targetType === "mcp"
+          ? mcpTransport === "streamable_http"
+            ? "MCP server URL is required."
+            : "MCP command is required."
+          : "Target base URL is required.",
+      );
       return;
     }
 
@@ -640,41 +739,219 @@ export default function NewScanPage() {
                 </div>
               </FieldRow>
 
-              {/* Base URL */}
-              <FieldRow label="Base URL *" hint="The root URL of your target application">
-                <input
-                  type="url"
-                  value={baseUrl}
-                  onChange={(e) => setBaseUrl(e.target.value)}
-                  placeholder="https://api.example.com"
-                  required
-                  className={inputCls}
-                />
-              </FieldRow>
+              {/* ── HTTP Agent fields ── */}
+              {targetType === "http_agent" && (
+                <>
+                  <FieldRow label="Base URL *" hint="The root URL of your target application">
+                    <input
+                      type="url"
+                      value={baseUrl}
+                      onChange={(e) => setBaseUrl(e.target.value)}
+                      placeholder="https://api.example.com"
+                      className={inputCls}
+                    />
+                  </FieldRow>
+                  <div className="grid grid-cols-2 gap-4">
+                    <FieldRow label="Agent Endpoint" hint="Path to the agent/chat endpoint">
+                      <input
+                        type="text"
+                        value={agentEndpoint}
+                        onChange={(e) => setAgentEndpoint(e.target.value)}
+                        placeholder="/api/agent"
+                        className={inputCls}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Auth Endpoint" hint="Login/token endpoint (if any)">
+                      <input
+                        type="text"
+                        value={authEndpoint}
+                        onChange={(e) => setAuthEndpoint(e.target.value)}
+                        placeholder="/api/auth/login"
+                        className={inputCls}
+                      />
+                    </FieldRow>
+                  </div>
+                </>
+              )}
 
-              <div className="grid grid-cols-2 gap-4">
-                {/* Agent Endpoint */}
-                <FieldRow label="Agent Endpoint" hint="Path to the agent/chat endpoint">
-                  <input
-                    type="text"
-                    value={agentEndpoint}
-                    onChange={(e) => setAgentEndpoint(e.target.value)}
-                    placeholder="/api/agent"
-                    className={inputCls}
-                  />
-                </FieldRow>
+              {/* ── MCP fields ── */}
+              {targetType === "mcp" && (
+                <div className="space-y-4">
+                  <FieldRow label="Transport" hint="How the scanner connects to your MCP server">
+                    <div className="flex gap-2">
+                      {(
+                        [
+                          { value: "streamable_http", label: "Streamable HTTP", desc: "Remote server (URL)" },
+                          { value: "stdio", label: "Stdio", desc: "Local process (command)" },
+                        ] as const
+                      ).map((t) => (
+                        <button
+                          key={t.value}
+                          type="button"
+                          onClick={() => setMcpTransport(t.value)}
+                          className={`flex-1 px-3 py-2 rounded-lg text-left border transition-all ${
+                            mcpTransport === t.value
+                              ? "border-primary bg-primary/5"
+                              : "border-border hover:border-muted-foreground/30"
+                          }`}
+                        >
+                          <div className="text-xs font-semibold text-foreground">{t.label}</div>
+                          <div className="text-[11px] text-muted-foreground">{t.desc}</div>
+                        </button>
+                      ))}
+                    </div>
+                  </FieldRow>
 
-                {/* Auth Endpoint */}
-                <FieldRow label="Auth Endpoint" hint="Login/token endpoint (if any)">
-                  <input
-                    type="text"
-                    value={authEndpoint}
-                    onChange={(e) => setAuthEndpoint(e.target.value)}
-                    placeholder="/api/auth/login"
-                    className={inputCls}
-                  />
-                </FieldRow>
-              </div>
+                  {mcpTransport === "streamable_http" ? (
+                    <>
+                      <FieldRow label="MCP Server URL *" hint="The MCP endpoint (streamable HTTP)">
+                        <input
+                          type="url"
+                          value={mcpUrl}
+                          onChange={(e) => setMcpUrl(e.target.value)}
+                          placeholder="https://your-mcp-server.example.com/api/mcp"
+                          className={inputCls}
+                        />
+                      </FieldRow>
+                      <FieldRow label="Headers" hint="Auth headers sent to the MCP server (e.g. x-api-key)">
+                        <div className="space-y-2">
+                          {mcpHeaders.map((h, i) => (
+                            <div key={i} className="flex gap-2">
+                              <input
+                                type="text"
+                                value={h.key}
+                                onChange={(e) => {
+                                  const copy = [...mcpHeaders];
+                                  copy[i] = { ...h, key: e.target.value };
+                                  setMcpHeaders(copy);
+                                }}
+                                placeholder="Header name (e.g. x-api-key)"
+                                className={`${inputCls} w-1/3`}
+                              />
+                              <input
+                                type="text"
+                                value={h.value}
+                                onChange={(e) => {
+                                  const copy = [...mcpHeaders];
+                                  copy[i] = { ...h, value: e.target.value };
+                                  setMcpHeaders(copy);
+                                }}
+                                placeholder="Value"
+                                className={`${inputCls} flex-1`}
+                              />
+                              {mcpHeaders.length > 1 && (
+                                <button
+                                  type="button"
+                                  onClick={() => setMcpHeaders(mcpHeaders.filter((_, j) => j !== i))}
+                                  className="text-muted-foreground hover:text-red-500 px-1"
+                                >
+                                  <X className="w-4 h-4" />
+                                </button>
+                              )}
+                            </div>
+                          ))}
+                          <button
+                            type="button"
+                            onClick={() => setMcpHeaders([...mcpHeaders, { key: "", value: "" }])}
+                            className="text-xs font-medium text-primary hover:text-primary/80"
+                          >
+                            + Add header
+                          </button>
+                        </div>
+                      </FieldRow>
+                    </>
+                  ) : (
+                    <div className="grid grid-cols-2 gap-4">
+                      <FieldRow label="Command *" hint="Executable that starts the MCP server">
+                        <input
+                          type="text"
+                          value={mcpCommand}
+                          onChange={(e) => setMcpCommand(e.target.value)}
+                          placeholder="npx"
+                          className={inputCls}
+                        />
+                      </FieldRow>
+                      <FieldRow label="Arguments" hint="Space-separated args passed to the command">
+                        <input
+                          type="text"
+                          value={mcpArgs}
+                          onChange={(e) => setMcpArgs(e.target.value)}
+                          placeholder="-y @modelcontextprotocol/server-filesystem /data"
+                          className={inputCls}
+                        />
+                      </FieldRow>
+                    </div>
+                  )}
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <FieldRow label="Tool Allowlist" hint="Only test these tools (comma/newline separated). Empty = all.">
+                      <textarea
+                        value={mcpAllowlist}
+                        onChange={(e) => setMcpAllowlist(e.target.value)}
+                        placeholder="read_file, search_docs"
+                        rows={2}
+                        className={`${inputCls} resize-y`}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Tool Denylist" hint="Never test these tools (keep destructive ops out of scope).">
+                      <textarea
+                        value={mcpDenylist}
+                        onChange={(e) => setMcpDenylist(e.target.value)}
+                        placeholder="delete_all, wire_transfer"
+                        rows={2}
+                        className={`${inputCls} resize-y`}
+                      />
+                    </FieldRow>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground">
+                    The scanner connects, auto-discovers the server&rsquo;s tools, prompts, and resources, then runs MCP-specific attacks (tool misuse, cross-tenant access, path traversal, SSRF, indirect prompt injection) against them.
+                  </p>
+                </div>
+              )}
+
+              {/* ── WebSocket fields ── */}
+              {targetType === "websocket_agent" && (
+                <>
+                  <FieldRow label="Base URL *" hint="Host of the target (the WebSocket connects on this host)">
+                    <input
+                      type="url"
+                      value={baseUrl}
+                      onChange={(e) => setBaseUrl(e.target.value)}
+                      placeholder="https://api.example.com"
+                      className={inputCls}
+                    />
+                  </FieldRow>
+                  <div className="grid grid-cols-2 gap-4">
+                    <FieldRow label="WebSocket Path *" hint="Path for the chat socket on the same host">
+                      <input
+                        type="text"
+                        value={wsPath}
+                        onChange={(e) => setWsPath(e.target.value)}
+                        placeholder="/ws/chat"
+                        className={inputCls}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Subprotocols" hint="Optional, comma-separated">
+                      <input
+                        type="text"
+                        value={wsSubprotocols}
+                        onChange={(e) => setWsSubprotocols(e.target.value)}
+                        placeholder="graphql-ws"
+                        className={inputCls}
+                      />
+                    </FieldRow>
+                  </div>
+                  <FieldRow label="Token" hint="Optional auth token appended as a query param">
+                    <input
+                      type="text"
+                      value={wsToken}
+                      onChange={(e) => setWsToken(e.target.value)}
+                      placeholder="Bearer/session token (if required)"
+                      className={inputCls}
+                    />
+                  </FieldRow>
+                </>
+              )}
 
               {/* Application Details */}
               <FieldRow
@@ -1353,7 +1630,7 @@ export default function NewScanPage() {
         {/* ═══ Submit ═══ */}
         <button
           type="submit"
-          disabled={submitting || (!baseUrl.trim() && !(showJsonOverride && jsonConfig.trim()))}
+          disabled={submitting || !targetReady}
           className="w-full flex items-center justify-center gap-2.5 px-6 py-4 bg-primary text-white font-semibold rounded-xl hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-all shadow-sm hover:shadow-md active:scale-[0.99]"
         >
           {submitting ? (

--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate, useLocation } from "react-router";
 import { createRun } from "@/api/runs";
-import { getReference } from "@/api/reference";
+import { getReference, discoverMcp } from "@/api/reference";
 import { apiFetch } from "@/api/client";
-import type { ReferenceData, StrategyInfo } from "@/api/types";
+import type { ReferenceData, StrategyInfo, McpDiscoverResult } from "@/api/types";
 import {
   Card,
   CardContent,
@@ -224,6 +224,9 @@ export default function NewScanPage() {
   const [mcpHeaders, setMcpHeaders] = useState<{ key: string; value: string }[]>([{ key: "", value: "" }]);
   const [mcpAllowlist, setMcpAllowlist] = useState(""); // comma/newline-separated tool names
   const [mcpDenylist, setMcpDenylist] = useState("");
+  const [mcpDiscovering, setMcpDiscovering] = useState(false);
+  const [mcpDiscovery, setMcpDiscovery] = useState<McpDiscoverResult | null>(null);
+  const [mcpDiscoverError, setMcpDiscoverError] = useState<string | null>(null);
 
   // ── WebSocket target (when targetType === "websocket_agent") ──
   const [wsPath, setWsPath] = useState("/ws/chat");
@@ -304,6 +307,13 @@ export default function NewScanPage() {
       .catch(() => setError("Failed to load reference data."))
       .finally(() => setRefLoading(false));
   }, []);
+
+  // If this instance disallows MCP stdio, never leave the form stuck on it.
+  useEffect(() => {
+    if (ref && !ref.allowMcpStdio && mcpTransport === "stdio") {
+      setMcpTransport("streamable_http");
+    }
+  }, [ref, mcpTransport]);
 
   // Pre-fill form from "Edit & Rerun" config passed via router state
   useEffect(() => {
@@ -609,6 +619,39 @@ export default function NewScanPage() {
     }
   };
 
+  // Connect to the MCP target and list its tools/prompts/resources.
+  const handleDiscover = async () => {
+    setMcpDiscoverError(null);
+    setMcpDiscovery(null);
+    const missing =
+      mcpTransport === "streamable_http" ? !mcpUrl.trim() : !mcpCommand.trim();
+    if (missing) {
+      setMcpDiscoverError(
+        mcpTransport === "streamable_http"
+          ? "Enter the MCP server URL first."
+          : "Enter the MCP command first.",
+      );
+      return;
+    }
+    setMcpDiscovering(true);
+    try {
+      const result = await discoverMcp(buildConfig());
+      if (result.ok) setMcpDiscovery(result);
+      else setMcpDiscoverError(result.error || "Could not connect to the MCP server.");
+    } catch (err) {
+      setMcpDiscoverError(err instanceof Error ? err.message : "Discovery failed.");
+    } finally {
+      setMcpDiscovering(false);
+    }
+  };
+
+  // Append a discovered tool name to the allowlist (dedup).
+  const addToAllowlist = (tool: string) => {
+    const current = mcpAllowlist.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);
+    if (current.includes(tool)) return;
+    setMcpAllowlist([...current, tool].join(", "));
+  };
+
   if (refLoading) {
     return (
       <div className="flex items-center justify-center py-32">
@@ -784,22 +827,31 @@ export default function NewScanPage() {
                           { value: "streamable_http", label: "Streamable HTTP", desc: "Remote server (URL)" },
                           { value: "stdio", label: "Stdio", desc: "Local process (command)" },
                         ] as const
-                      ).map((t) => (
-                        <button
-                          key={t.value}
-                          type="button"
-                          onClick={() => setMcpTransport(t.value)}
-                          className={`flex-1 px-3 py-2 rounded-lg text-left border transition-all ${
-                            mcpTransport === t.value
-                              ? "border-primary bg-primary/5"
-                              : "border-border hover:border-muted-foreground/30"
-                          }`}
-                        >
-                          <div className="text-xs font-semibold text-foreground">{t.label}</div>
-                          <div className="text-[11px] text-muted-foreground">{t.desc}</div>
-                        </button>
-                      ))}
+                      )
+                        // Stdio spawns a local process on the server, so it's only
+                        // offered on instances that explicitly enable it.
+                        .filter((t) => t.value !== "stdio" || ref?.allowMcpStdio)
+                        .map((t) => (
+                          <button
+                            key={t.value}
+                            type="button"
+                            onClick={() => setMcpTransport(t.value)}
+                            className={`flex-1 px-3 py-2 rounded-lg text-left border transition-all ${
+                              mcpTransport === t.value
+                                ? "border-primary bg-primary/5"
+                                : "border-border hover:border-muted-foreground/30"
+                            }`}
+                          >
+                            <div className="text-xs font-semibold text-foreground">{t.label}</div>
+                            <div className="text-[11px] text-muted-foreground">{t.desc}</div>
+                          </button>
+                        ))}
                     </div>
+                    {!ref?.allowMcpStdio && (
+                      <p className="text-[11px] text-muted-foreground mt-1.5">
+                        Stdio (local process) targets are disabled on this instance. Connect a remote MCP server over Streamable HTTP.
+                      </p>
+                    )}
                   </FieldRow>
 
                   {mcpTransport === "streamable_http" ? (
@@ -882,6 +934,67 @@ export default function NewScanPage() {
                       </FieldRow>
                     </div>
                   )}
+
+                  {/* Test connection & discover tools */}
+                  <div>
+                    <button
+                      type="button"
+                      onClick={handleDiscover}
+                      disabled={mcpDiscovering}
+                      className="inline-flex items-center gap-2 px-3 py-2 text-xs font-medium border border-border rounded-lg hover:border-primary hover:text-primary transition-colors disabled:opacity-50"
+                    >
+                      {mcpDiscovering ? (
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      ) : (
+                        <Globe className="w-3.5 h-3.5" />
+                      )}
+                      {mcpDiscovering ? "Connecting..." : "Test connection & discover tools"}
+                    </button>
+
+                    {mcpDiscoverError && (
+                      <div className="mt-2 flex items-start gap-2 p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-lg text-xs text-red-700 dark:text-red-400">
+                        <AlertCircle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+                        <span>{mcpDiscoverError}</span>
+                      </div>
+                    )}
+
+                    {mcpDiscovery?.ok && (
+                      <div className="mt-2 p-3 bg-emerald-50/50 dark:bg-emerald-950/20 border border-emerald-200 dark:border-emerald-900 rounded-lg">
+                        <div className="flex items-center gap-2 text-xs font-medium text-emerald-700 dark:text-emerald-400 mb-2">
+                          <CheckCircle className="w-3.5 h-3.5" />
+                          Connected{mcpDiscovery.serverInfo?.name ? ` to ${mcpDiscovery.serverInfo.name}` : ""}
+                          {mcpDiscovery.serverInfo?.version ? ` v${mcpDiscovery.serverInfo.version}` : ""}
+                          <span className="text-muted-foreground font-normal">
+                            · {mcpDiscovery.tools?.length ?? 0} tools · {mcpDiscovery.prompts?.length ?? 0} prompts · {mcpDiscovery.resources?.length ?? 0} resources
+                          </span>
+                        </div>
+                        {(mcpDiscovery.tools?.length ?? 0) > 0 ? (
+                          <>
+                            <p className="text-[11px] text-muted-foreground mb-1.5">
+                              Discovered tools (click to add to the allowlist):
+                            </p>
+                            <div className="flex flex-wrap gap-1.5">
+                              {mcpDiscovery.tools!.map((t) => (
+                                <button
+                                  key={t.name}
+                                  type="button"
+                                  onClick={() => addToAllowlist(t.name)}
+                                  title={t.description || t.name}
+                                  className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium border border-border bg-card hover:border-primary hover:text-primary transition-colors"
+                                >
+                                  {t.name}
+                                </button>
+                              ))}
+                            </div>
+                          </>
+                        ) : (
+                          <p className="text-[11px] text-muted-foreground">
+                            The server exposed no tools.
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
 
                   <div className="grid grid-cols-2 gap-4">
                     <FieldRow label="Tool Allowlist" hint="Only test these tools (comma/newline separated). Empty = all.">


### PR DESCRIPTION
## Why
Customers want to connect their **AI tools** (MCP servers) for testing. The backend fully supports MCP (stdio + streamable HTTP) and WebSocket targets, but the Launch Scan **form** only collected `type` + `baseUrl` — so picking MCP/WebSocket failed backend validation (`target.mcp` / `target.websocket.path` required). MCP/WS scans could only be set up via the raw JSON override.

## What
Step 2 (Configure target) now renders fields conditionally by target type:

- **MCP** — transport toggle (**Streamable HTTP** / **Stdio**); for HTTP: server URL + auth headers (key/value list); for stdio: command + args. Optional **tool allowlist/denylist** to keep testing in scope, plus a short note explaining that the scanner auto-discovers tools/prompts/resources and runs MCP-specific attacks against them.
- **WebSocket** — base URL + socket path + optional subprotocols and token.
- **HTTP Agent** — unchanged.

`buildConfig` emits `target.mcp` / `target.websocket` blocks that match `lib/config-loader.ts` validation exactly (verified against each branch). Submit-button validation and **Edit & Rerun** prefill updated per target type. Only `sse` transport is omitted from the UI since it isn't implemented in `createMcpTransport` yet.

Scoped to `dashboard/ui/src/pages/NewScanPage/index.tsx`. `tsc` + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)