### PR TITLE
config-loader: default request/response schema so minimal configs don…

### DIFF
--- a/lib/config-loader.ts
+++ b/lib/config-loader.ts
@@ -83,6 +83,28 @@ function validateAndNormalizeConfig(config: Config): Config {
       "Warning: no auth credentials or apiKeys provided — scanning the target as an unauthenticated/public endpoint",
     );
   }
+
+  // Request/response schema defaults. The response analyzer reads these paths on
+  // every result (config.responseSchema.toolCallsPath, etc.), so a config that
+  // omits them — e.g. a minimal MCP config — must not crash at analysis time.
+  config.requestSchema = Object.assign(
+    {
+      messageField: "message",
+      roleField: "role",
+      apiKeyField: "api_key",
+      guardrailModeField: "guardrail_mode",
+    },
+    config.requestSchema ?? {},
+  );
+  config.responseSchema = Object.assign(
+    {
+      responsePath: "response",
+      toolCallsPath: "tool_calls",
+      userInfoPath: "user",
+      guardrailsPath: "guardrails",
+    },
+    config.responseSchema ?? {},
+  );
   if (!config.sensitivePatterns?.length) {
     config.sensitivePatterns = [];
     if (config.attackConfig.enableDiscovery) {

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -262,6 +262,20 @@ describe("loadConfig", () => {
     expect(config.auth.methods).toEqual([]);
   });
 
+  it("defaults request/response schema when omitted (e.g. a minimal MCP config)", () => {
+    const cfg = makeValidConfig();
+    delete cfg.requestSchema;
+    delete cfg.responseSchema;
+    const path = writeTestConfig(tmpDir, cfg);
+    const config = loadConfig(path);
+    // The response analyzer reads these on every result — they must exist.
+    expect(config.responseSchema.toolCallsPath).toBe("tool_calls");
+    expect(config.responseSchema.responsePath).toBe("response");
+    expect(config.responseSchema.userInfoPath).toBe("user");
+    expect(config.responseSchema.guardrailsPath).toBe("guardrails");
+    expect(config.requestSchema.messageField).toBe("message");
+  });
+
   it("throws on non-existent config file", () => {
     expect(() => loadConfig("/nonexistent/path/config.json")).toThrow();
   });


### PR DESCRIPTION
…'t crash

The response analyzer reads config.responseSchema.toolCallsPath (and responsePath, userInfoPath, guardrailsPath) on every result. config-loader never defaulted these, so a config omitting responseSchema/requestSchema — e.g. a minimal MCP config — crashed every attack with "Cannot read properties of undefined (reading 'toolCallsPath')".

Default both schemas (provided fields still override). Added a regression test.