### PR TITLE
fix: MCP capability gating + judge-policy layout overlap

### DIFF
--- a/dashboard/ui/src/pages/ReportsPage/index.tsx
+++ b/dashboard/ui/src/pages/ReportsPage/index.tsx
@@ -612,27 +612,27 @@ function FindingRow({ result }: { result: ReportResult }) {
                   <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1.5">
                     Judge Policy — {result.policyUsed.name}
                   </div>
-                  <div className="grid grid-cols-3 gap-2 text-xs">
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-x-4 gap-y-3 text-xs">
                     {result.policyUsed.pass_criteria && result.policyUsed.pass_criteria.length > 0 && (
-                      <div>
+                      <div className="min-w-0">
                         <span className="font-semibold text-emerald-600 dark:text-emerald-400">PASS criteria:</span>
-                        <ul className="list-disc list-inside text-muted-foreground mt-0.5 space-y-0.5">
+                        <ul className="list-disc pl-4 text-muted-foreground mt-0.5 space-y-0.5 break-words">
                           {result.policyUsed.pass_criteria.map((c, i) => <li key={i}>{c}</li>)}
                         </ul>
                       </div>
                     )}
                     {result.policyUsed.fail_criteria && result.policyUsed.fail_criteria.length > 0 && (
-                      <div>
+                      <div className="min-w-0">
                         <span className="font-semibold text-red-600 dark:text-red-400">FAIL criteria:</span>
-                        <ul className="list-disc list-inside text-muted-foreground mt-0.5 space-y-0.5">
+                        <ul className="list-disc pl-4 text-muted-foreground mt-0.5 space-y-0.5 break-words">
                           {result.policyUsed.fail_criteria.map((c, i) => <li key={i}>{c}</li>)}
                         </ul>
                       </div>
                     )}
                     {result.policyUsed.partial_criteria && result.policyUsed.partial_criteria.length > 0 && (
-                      <div>
+                      <div className="min-w-0">
                         <span className="font-semibold text-amber-600 dark:text-amber-400">PARTIAL criteria:</span>
-                        <ul className="list-disc list-inside text-muted-foreground mt-0.5 space-y-0.5">
+                        <ul className="list-disc pl-4 text-muted-foreground mt-0.5 space-y-0.5 break-words">
                           {result.policyUsed.partial_criteria.map((c, i) => <li key={i}>{c}</li>)}
                         </ul>
                       </div>

--- a/lib/run.ts
+++ b/lib/run.ts
@@ -670,24 +670,37 @@ export async function runRedTeam(
     if (signal?.aborted) throw new Error("Run cancelled");
   };
 
-  // For MCP targets, only "_mcpOperation" payloads can actually execute against
-  // the server. Chat-shaped attacks (e.g. from LLM/strategy/multi-turn generation)
-  // would be rejected with HTTP 400 and then scored a FALSE "Defended", inflating
-  // the target's security. Drop them here so results reflect real MCP calls only.
+  // Populated after codebase/target analysis; used to gate MCP attacks by the
+  // server's discovered capabilities (see keepExecutableForTarget below).
+  let mcpAnalysis: CodebaseAnalysis | undefined;
+
+  // For MCP targets, drop attacks that can't actually execute against the server,
+  // so results reflect real MCP calls instead of false "Defended"/"Error" noise:
+  //  1. no "_mcpOperation" — a chat-shaped payload (LLM/strategy/multi-turn) that
+  //     the adapter rejects with HTTP 400 → falsely scored "Defended".
+  //  2. an operation the server doesn't expose (e.g. prompts/get or resources/read
+  //     on a tools-only server) → JSON-RPC -32601 "Method not found".
   const keepExecutableForTarget = (
     list: Attack[],
     round: number,
   ): Attack[] => {
     if ((config.target.type ?? "http_agent") !== "mcp") return list;
-    const kept = list.filter(
-      (a) =>
-        typeof (a.payload as Record<string, unknown>)?._mcpOperation === "string",
-    );
+    const surface = mcpAnalysis?.mcpSurface;
+    const caps = surface?.capabilities ?? [];
+    const hasPrompts = caps.includes("prompts") || (surface?.prompts?.length ?? 0) > 0;
+    const hasResources = caps.includes("resources") || (surface?.resources?.length ?? 0) > 0;
+    const kept = list.filter((a) => {
+      const op = (a.payload as Record<string, unknown>)?._mcpOperation;
+      if (typeof op !== "string") return false;
+      if (op === "prompts/get" && !hasPrompts) return false;
+      if (op === "resources/read" && !hasResources) return false;
+      return true;
+    });
     const dropped = list.length - kept.length;
     if (dropped > 0) {
       log(
         "attacks",
-        `MCP target: skipped ${dropped} non-MCP attack(s) lacking "_mcpOperation" (a chat-shaped payload can't call an MCP tool, so it isn't a real defense)`,
+        `MCP target: skipped ${dropped} attack(s) that can't run here (no "_mcpOperation", or the server doesn't expose prompts/resources)`,
         { round },
       );
     }
@@ -811,6 +824,7 @@ export async function runRedTeam(
   await enrichAnalysisWithTargetSurface(config, analysis, (msg) =>
     log("analyze", msg),
   );
+  mcpAnalysis = analysis; // expose discovered MCP surface to the attack filter
   log(
     "analyze",
     `Found ${analysis.tools.length} tools, ${analysis.roles.length} roles`,


### PR DESCRIPTION
MCP: skip attacks whose operation the server doesn't expose. A tools-only server (no prompts/resources capability) returned JSON-RPC -32601 "Method not found" for resources/read and prompts/get attacks, surfacing as misleading "target unreachable" errors. keepExecutableForTarget now also drops prompts/get and resources/read when the discovered mcpSurface has no such capability.

UI: the judge-policy PASS/FAIL/PARTIAL criteria used a 3-col grid whose items had default min-width:auto, so long criteria overflowed their tracks and overlapped. Make it responsive (stack on small, 3-col on md+) with min-w-0 + break-words.