### PR TITLE
fix(rbac): allow dataset/eval endpoints — fixes post-login 403 logout…

### DIFF
--- a/dashboard/ui/src/components/auth/LoginForm.tsx
+++ b/dashboard/ui/src/components/auth/LoginForm.tsx
@@ -50,7 +50,7 @@ export function LoginForm() {
           </div>
           <div>
             <h1 className="text-xl font-bold text-foreground tracking-tight">
-              Red Team Dashboard
+              Red-Team AI
             </h1>
             <p className="text-sm text-muted-foreground">
               Sign in with your credentials

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -78,6 +78,15 @@ const PERMISSIONS: RoutePermission[] = [
     roles: ["admin"],
   },
 
+  // Datasets & Evaluations
+  { method: "GET", pattern: /^\/api\/datasets$/, roles: ["admin", "viewer"] },
+  {
+    method: "POST",
+    pattern: /^\/api\/datasets\/generate$/,
+    roles: ["admin"],
+  },
+  { method: "GET", pattern: /^\/api\/eval-runs$/, roles: ["admin", "viewer"] },
+
   // Audit log
   { method: "GET", pattern: /^\/api\/audit-log/, roles: ["admin", "auditor"] },
 

--- a/tests/rbac-datasets.test.ts
+++ b/tests/rbac-datasets.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { checkPermission } from "../lib/rbac.js";
+
+describe("RBAC for dataset/eval endpoints (regression: login-loop 403)", () => {
+  it("allows viewer+admin to GET datasets and eval-runs", () => {
+    expect(checkPermission("GET", "/api/datasets", "viewer")).toBe(true);
+    expect(checkPermission("GET", "/api/datasets", "admin")).toBe(true);
+    expect(checkPermission("GET", "/api/eval-runs", "viewer")).toBe(true);
+  });
+  it("restricts dataset generation to admin", () => {
+    expect(checkPermission("POST", "/api/datasets/generate", "admin")).toBe(true);
+    expect(checkPermission("POST", "/api/datasets/generate", "viewer")).toBe(false);
+  });
+  it("GET /api/datasets pattern does not swallow the generate path", () => {
+    // ensure the two rules stay distinct
+    expect(checkPermission("GET", "/api/datasets/generate", "viewer")).toBe(false);
+  });
+});


### PR DESCRIPTION
… loop

The new /api/datasets, /api/datasets/generate, and /api/eval-runs endpoints had no RBAC rule, so checkPermission denied them (403) even for authenticated users. apiFetch treats any 403 as an auth failure and calls logout(), so after login the Datasets page (and Launch Scan, which fetches datasets on mount) triggered a 403 -> forced logout -> back to login. That presented as 'sign-in failing'.

- lib/rbac.ts: GET /api/datasets + /api/eval-runs (admin,viewer); POST /api/datasets/generate (admin)
- tests/rbac-datasets.test.ts: regression coverage
- rename login title 'Red Team Dashboard' -> 'Red-Team AI' (matches product name)

Verified: root tsc + 479 tests green; dashboard tsc -b + vite build green.


Claude-Session: https://claude.ai/code/session_01JqYmqQHdzxq14xN8pEHLxM