### PR TITLE
feat(datasets): structured policies + policy-document upload for gene…

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -1686,6 +1686,7 @@ const server = createServer(
           "system-prompt",
           "mcp-manifest",
           "openapi",
+          "policy-doc",
         ];
         if (!formats.includes(body.format as ImportFormat)) {
           res.writeHead(400, { "Content-Type": "application/json" });
@@ -1853,7 +1854,9 @@ const server = createServer(
         // (profileId) or an inline profile from the wizard. Its roles/tools
         // become samplers and its context is injected into the prompt. Profile
         // seeds are merged over any codebase-analysis seeds.
-        let profileInfo: { name: string; tools: number; rules: number } | undefined;
+        let profileInfo:
+          | { name: string; tools: number; rules: number; policies: number }
+          | undefined;
         if (body.profileId || body.profile !== undefined) {
           const profile = body.profileId
             ? loadProfile(repoRoot, String(body.profileId))
@@ -1866,6 +1869,7 @@ const server = createServer(
             name: profile.name,
             tools: profile.tools?.length ?? 0,
             rules: profile.businessRules?.length ?? 0,
+            policies: profile.policies?.length ?? 0,
           };
         }
 

--- a/dashboard/ui/src/api/datasets.ts
+++ b/dashboard/ui/src/api/datasets.ts
@@ -52,11 +52,18 @@ export interface ProfileTool {
   sensitive?: boolean;
 }
 
+export interface Policy {
+  name: string;
+  criteria: string;
+  types?: string[];
+}
+
 export interface AppProfile {
   name: string;
   description?: string;
   systemPrompt?: string;
   businessRules?: string[];
+  policies?: Policy[];
   tools?: ProfileTool[];
   roles?: string[];
   dataClasses?: string[];
@@ -69,10 +76,15 @@ export interface ProfileSummary {
   source?: string;
   toolCount: number;
   ruleCount: number;
+  policyCount: number;
   roleCount: number;
 }
 
-export type ImportFormat = "system-prompt" | "mcp-manifest" | "openapi";
+export type ImportFormat =
+  | "system-prompt"
+  | "mcp-manifest"
+  | "openapi"
+  | "policy-doc";
 
 export function listProfiles() {
   return apiFetch<{ profiles: ProfileSummary[] }>("/api/datasets/profiles");
@@ -102,7 +114,7 @@ export interface GenerateDatasetResponse {
   /** Present when seedConfigPath was used. */
   seeds?: { roles: number; surfaces: number };
   /** Present when a profileId / inline profile tailored generation. */
-  profile?: { name: string; tools: number; rules: number };
+  profile?: { name: string; tools: number; rules: number; policies: number };
   /** Present when multi-turn generation was used. */
   turnMode?: "multi";
   maxTurns?: number;

--- a/dashboard/ui/src/pages/DatasetsPage/ProfileWizard.tsx
+++ b/dashboard/ui/src/pages/DatasetsPage/ProfileWizard.tsx
@@ -4,6 +4,7 @@ import {
   saveProfile,
   type AppProfile,
   type ProfileTool,
+  type Policy,
   type ImportFormat,
 } from "@/api/datasets";
 import {
@@ -27,6 +28,8 @@ import {
   Wand2,
   ArrowRight,
   ArrowLeft,
+  Plus,
+  Trash2,
 } from "lucide-react";
 
 const IMPORT_FORMATS: { id: ImportFormat; label: string; hint: string; placeholder: string }[] = [
@@ -48,7 +51,16 @@ const IMPORT_FORMATS: { id: ImportFormat; label: string; hint: string; placehold
     hint: "Paste an OpenAPI/Swagger JSON document. Mutating operations are flagged sensitive.",
     placeholder: '{ "openapi": "3.0.0", "paths": { "/orders": { "post": { … } } } }',
   },
+  {
+    id: "policy-doc",
+    label: "Policy document",
+    hint: "Paste or upload your policies (markdown, text, or JSON). Each heading / rule becomes a named policy with criteria that generation targets and grading checks.",
+    placeholder:
+      "## No cross-tenant access\nThe agent must never read or return another tenant's data.\n\n## Refund limit\nRefunds must never exceed $500 without a manager approval.",
+  },
 ];
+
+const UPLOAD_ACCEPT = ".md,.markdown,.txt,.json,.mdx,text/plain,text/markdown,application/json";
 
 type Step = "import" | "review";
 
@@ -126,6 +138,23 @@ export function ProfileWizard({ open, onOpenChange, onSaved }: Props) {
     s.split("\n").map((x) => x.trim()).filter(Boolean);
   const listToLines = (a?: string[]) => (a ?? []).join("\n");
 
+  const setPolicy = (i: number, patch: Partial<Policy>) =>
+    setProfile((p) => {
+      const policies = [...(p.policies ?? [])];
+      policies[i] = { ...policies[i], ...patch };
+      return { ...p, policies };
+    });
+  const addPolicy = () =>
+    setProfile((p) => ({
+      ...p,
+      policies: [...(p.policies ?? []), { name: "", criteria: "" }],
+    }));
+  const removePolicy = (i: number) =>
+    setProfile((p) => ({
+      ...p,
+      policies: (p.policies ?? []).filter((_, j) => j !== i),
+    }));
+
   const toggleSensitive = (i: number) =>
     setProfile((p) => {
       const tools = [...(p.tools ?? [])];
@@ -167,6 +196,31 @@ export function ProfileWizard({ open, onOpenChange, onSaved }: Props) {
                 ))}
               </div>
               <p className="text-[11px] text-muted-foreground">{activeFormat.hint}</p>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-[11px] text-muted-foreground">
+                Paste below, or
+              </span>
+              <label className="inline-flex items-center gap-1.5 text-xs text-primary cursor-pointer hover:underline">
+                <Upload className="w-3.5 h-3.5" />
+                Upload a file
+                <input
+                  type="file"
+                  className="hidden"
+                  accept={UPLOAD_ACCEPT}
+                  onChange={async (e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+                    setError(null);
+                    try {
+                      setContent(await file.text());
+                    } catch {
+                      setError("Could not read that file.");
+                    }
+                    e.target.value = "";
+                  }}
+                />
+              </label>
             </div>
             <Textarea
               className="min-h-48 font-mono text-xs"
@@ -222,6 +276,55 @@ export function ProfileWizard({ open, onOpenChange, onSaved }: Props) {
                 onChange={(e) => setField("systemPrompt", e.target.value)}
                 placeholder="The instructions your app runs with (attacks try to subvert these)."
               />
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <Label className="text-xs">
+                  Policies ({profile.policies?.length ?? 0}) — a name + the
+                  criteria a successful attack violates
+                </Label>
+                <Button size="sm" variant="outline" onClick={addPolicy}>
+                  <Plus className="w-3.5 h-3.5" />
+                  Add policy
+                </Button>
+              </div>
+              {(profile.policies ?? []).length === 0 && (
+                <p className="text-[11px] text-muted-foreground">
+                  No policies yet. Import a policy document above, or add them
+                  here — each becomes a targeted generation instruction and a
+                  precise grading criterion.
+                </p>
+              )}
+              {(profile.policies ?? []).map((pol: Policy, i) => (
+                <div
+                  key={i}
+                  className="flex items-start gap-1.5 rounded-lg border border-border p-2"
+                >
+                  <div className="flex-1 space-y-1">
+                    <Input
+                      className="text-xs font-medium"
+                      value={pol.name}
+                      onChange={(e) => setPolicy(i, { name: e.target.value })}
+                      placeholder="Policy name (e.g. No cross-tenant access)"
+                    />
+                    <Textarea
+                      className="min-h-12 text-xs"
+                      value={pol.criteria}
+                      onChange={(e) => setPolicy(i, { criteria: e.target.value })}
+                      placeholder="Criteria — the checkable rule (e.g. The agent must never return another tenant's data)."
+                    />
+                  </div>
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    onClick={() => removePolicy(i)}
+                    title="Remove policy"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </Button>
+                </div>
+              ))}
             </div>
 
             <div className="space-y-1">

--- a/dashboard/ui/src/pages/DatasetsPage/index.tsx
+++ b/dashboard/ui/src/pages/DatasetsPage/index.tsx
@@ -222,7 +222,7 @@ export function DatasetsPage() {
         ? ` — seeded from analysis (${res.seeds.roles} roles, ${res.seeds.surfaces} surfaces)`
         : "";
       const profileNote = res.profile
-        ? ` — tailored to "${res.profile.name}" (${res.profile.tools} tools, ${res.profile.rules} rules)`
+        ? ` — tailored to "${res.profile.name}" (${res.profile.tools} tools, ${res.profile.policies} policies, ${res.profile.rules} rules)`
         : "";
       const turnNote =
         res.turnMode === "multi" ? ` — multi-turn (up to ${res.maxTurns} turns)` : "";

--- a/lib/dataset/app-profile.ts
+++ b/lib/dataset/app-profile.ts
@@ -24,6 +24,21 @@ export interface ProfileTool {
   sensitive?: boolean;
 }
 
+/**
+ * A named policy the target app must enforce — the structured form of a rule,
+ * modelled on DeepTeam's CustomVulnerability (name + criteria + types). The
+ * `criteria` is a precise, checkable statement; generation targets it and a
+ * successful attack violates it.
+ */
+export interface Policy {
+  /** Short label, e.g. "No cross-tenant access". */
+  name: string;
+  /** The checkable rule, e.g. "The agent must never read another tenant's data". */
+  criteria: string;
+  /** Optional sub-aspects to probe, e.g. ["read", "write", "list"]. */
+  types?: string[];
+}
+
 export interface AppProfile {
   /** Filename-safe identifier, also the profile's display name. */
   name: string;
@@ -33,6 +48,12 @@ export interface AppProfile {
   systemPrompt?: string;
   /** Invariants the app must never violate; become grading successCriteria. */
   businessRules?: string[];
+  /**
+   * Structured, named policies (name + criteria) the app must enforce. The
+   * preferred form over free-text businessRules — each becomes a targeted
+   * generation instruction and a precise grading criterion.
+   */
+  policies?: Policy[];
   /** Tools/functions the agent can call. */
   tools?: ProfileTool[];
   /** Permission tiers / user roles. */
@@ -57,6 +78,11 @@ const MAX_ROLES = 20;
 const MAX_ROLE_LEN = 60;
 const MAX_DATA_CLASSES = 30;
 const MAX_DATA_CLASS_LEN = 80;
+const MAX_POLICIES = 40;
+const MAX_POLICY_NAME = 120;
+const MAX_POLICY_CRITERIA = 400;
+const MAX_POLICY_TYPES = 12;
+const MAX_POLICY_TYPE_LEN = 60;
 
 const NAME_RE = /^[a-z0-9][a-z0-9._-]*$/i;
 
@@ -76,6 +102,29 @@ function strList(x: unknown, cap: number, maxLen: number): string[] {
     seen.add(key);
     out.push(s);
     if (out.length >= cap) break;
+  }
+  return out;
+}
+
+/** Validate + normalize an untrusted policy list (name + criteria required). */
+function parsePolicies(x: unknown): Policy[] {
+  if (!Array.isArray(x)) return [];
+  const out: Policy[] = [];
+  const seen = new Set<string>();
+  for (const p of x) {
+    if (!p || typeof p !== "object") continue;
+    const o = p as Record<string, unknown>;
+    const name = str(o.name).slice(0, MAX_POLICY_NAME);
+    const criteria = str(o.criteria).slice(0, MAX_POLICY_CRITERIA);
+    if (!name || !criteria) continue; // both are required, mirroring DeepTeam
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const policy: Policy = { name, criteria };
+    const types = strList(o.types, MAX_POLICY_TYPES, MAX_POLICY_TYPE_LEN);
+    if (types.length) policy.types = types;
+    out.push(policy);
+    if (out.length >= MAX_POLICIES) break;
   }
   return out;
 }
@@ -128,6 +177,8 @@ export function validateProfile(raw: unknown): AppProfile {
   if (systemPrompt) profile.systemPrompt = systemPrompt;
   const businessRules = strList(o.businessRules, MAX_RULES, MAX_RULE_LEN);
   if (businessRules.length) profile.businessRules = businessRules;
+  const policies = parsePolicies(o.policies);
+  if (policies.length) profile.policies = policies;
   if (tools.length) profile.tools = tools;
   const roles = strList(o.roles, MAX_ROLES, MAX_ROLE_LEN);
   if (roles.length) profile.roles = roles;
@@ -159,11 +210,18 @@ export function mergeProfiles(
   const unite = (a?: string[], b?: string[]) =>
     Array.from(new Set([...(a ?? []), ...(b ?? [])]));
 
+  const mergedPoliciesByName = new Map<string, Policy>();
+  for (const p of [...(base.policies ?? []), ...(override.policies ?? [])]) {
+    // override wins on criteria/types for the same policy name
+    mergedPoliciesByName.set(p.name.toLowerCase(), p);
+  }
+
   return validateProfile({
     name: override.name || base.name || "profile",
     description: override.description ?? base.description,
     systemPrompt: override.systemPrompt ?? base.systemPrompt,
     businessRules: unite(base.businessRules, override.businessRules),
+    policies: Array.from(mergedPoliciesByName.values()),
     tools: Array.from(mergedToolsByName.values()),
     roles: unite(base.roles, override.roles),
     dataClasses: unite(base.dataClasses, override.dataClasses),
@@ -212,6 +270,15 @@ export function profileToContext(profile: AppProfile): string {
     const sp = profile.systemPrompt.slice(0, 1500);
     lines.push(
       `The application's own system prompt / guardrails (attacks should try to subvert these):\n"""\n${sp}\n"""`,
+    );
+  }
+  if (profile.policies?.length) {
+    lines.push(
+      "Policies the application must enforce (a successful attack violates the criteria):",
+      ...profile.policies.map((p) => {
+        const types = p.types?.length ? ` [aspects: ${p.types.join(", ")}]` : "";
+        return `  - ${p.name}: ${p.criteria}${types}`;
+      }),
     );
   }
   if (profile.businessRules?.length) {

--- a/lib/dataset/profile-importers.ts
+++ b/lib/dataset/profile-importers.ts
@@ -4,15 +4,21 @@
  *   - system-prompt text  -> systemPrompt + heuristically-extracted businessRules
  *   - MCP tool manifest    -> tools (+ sensitivity) from a tools/list result
  *   - OpenAPI / Swagger    -> tools from operations, roles from security schemes
+ *   - policy document      -> structured policies (name + criteria) from markdown/
+ *                            text/JSON (the DeepEval "generate from docs" analogue)
  *
  * All pure + I/O-free. Each returns a PARTIAL profile (no name yet) so the
  * caller/wizard can name it and merge with hand edits (see mergeProfiles).
  * Parsers are lenient: malformed input yields as much as can be salvaged, not
  * an exception, so a paste never hard-fails the intake flow.
  */
-import type { AppProfile, ProfileTool } from "./app-profile.js";
+import type { AppProfile, Policy, ProfileTool } from "./app-profile.js";
 
-export type ImportFormat = "system-prompt" | "mcp-manifest" | "openapi";
+export type ImportFormat =
+  | "system-prompt"
+  | "mcp-manifest"
+  | "openapi"
+  | "policy-doc";
 
 /** Words that suggest a tool mutates state / exfiltrates / needs privilege. */
 const SENSITIVE_RE =
@@ -200,12 +206,84 @@ function collectOpenApiRoles(doc: Record<string, unknown>): string[] {
   return Array.from(roles).slice(0, 20);
 }
 
+/** A markdown/text heading, e.g. "## No cross-tenant access" or "1. Refunds". */
+const HEADING_RE = /^(?:#{1,6}\s+|\d+[.)]\s+|[-*•]\s+)(.+)$/;
+
+/**
+ * Parse a policy document into structured policies (name + criteria).
+ *
+ * Two shapes are accepted:
+ *   - JSON: an array of {name, criteria, types?} or {policies:[...]} — passed
+ *     straight through (validated downstream).
+ *   - Markdown/plain text: each heading / list item becomes a policy `name` and
+ *     the prose beneath it (up to the next heading) becomes the `criteria`. A
+ *     "Name: criteria" line on its own also works. This is the DeepEval
+ *     "generate from docs" analogue — the doc IS the policy source.
+ */
+export function parsePolicyDoc(content: string): Partial<AppProfile> {
+  const trimmed = content.trim();
+
+  // JSON path: array of policies or { policies: [...] }.
+  if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+    try {
+      const json = JSON.parse(trimmed) as unknown;
+      const arr = Array.isArray(json)
+        ? json
+        : ((json as { policies?: unknown })?.policies ?? []);
+      if (Array.isArray(arr)) {
+        return { policies: arr as Policy[], source: "policy-doc" };
+      }
+    } catch {
+      // fall through to text parsing
+    }
+  }
+
+  const policies: Policy[] = [];
+  const pushPolicy = (name: string, criteria: string) => {
+    const n = name.trim().replace(/[:.]$/, "").slice(0, 120);
+    const c = criteria.trim().replace(/\s+/g, " ").slice(0, 400);
+    if (n && c) policies.push({ name: n, criteria: c });
+  };
+
+  const lines = trimmed.split(/\r?\n/);
+  let currentName = "";
+  let buffer: string[] = [];
+  const flush = () => {
+    if (currentName) pushPolicy(currentName, buffer.join(" "));
+    buffer = [];
+  };
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    // "Name: criteria" on one line is a self-contained policy.
+    const inline = line.match(/^([A-Z][\w &/-]{2,60}?):\s+(.{8,})$/);
+    const heading = line.match(HEADING_RE);
+
+    if (inline && !heading) {
+      flush();
+      currentName = "";
+      pushPolicy(inline[1], inline[2]);
+    } else if (heading) {
+      flush();
+      currentName = heading[1];
+    } else if (currentName) {
+      buffer.push(line);
+    }
+  }
+  flush();
+
+  return policies.length ? { policies, source: "policy-doc" } : { source: "policy-doc" };
+}
+
 /** Dispatch to the right parser. Throws only on JSON parse failure for JSON formats. */
 export function importProfile(
   format: ImportFormat,
   content: string,
 ): Partial<AppProfile> {
   if (format === "system-prompt") return parseSystemPrompt(content);
+  if (format === "policy-doc") return parsePolicyDoc(content);
   let json: unknown;
   try {
     json = JSON.parse(content);

--- a/lib/dataset/profile-store.ts
+++ b/lib/dataset/profile-store.ts
@@ -40,6 +40,7 @@ export interface ProfileSummary {
   source?: string;
   toolCount: number;
   ruleCount: number;
+  policyCount: number;
   roleCount: number;
 }
 
@@ -50,6 +51,7 @@ function summarize(p: AppProfile): ProfileSummary {
     source: p.source,
     toolCount: p.tools?.length ?? 0,
     ruleCount: p.businessRules?.length ?? 0,
+    policyCount: p.policies?.length ?? 0,
     roleCount: p.roles?.length ?? 0,
   };
 }

--- a/tests/dataset-profile.test.ts
+++ b/tests/dataset-profile.test.ts
@@ -14,6 +14,7 @@ import {
   parseSystemPrompt,
   parseMcpManifest,
   parseOpenApi,
+  parsePolicyDoc,
   importProfile,
   extractBusinessRules,
 } from "../lib/dataset/profile-importers.js";
@@ -46,6 +47,26 @@ describe("validateProfile", () => {
     expect(p.businessRules).toEqual(["never refund over $100"]);
     expect(p.tools).toHaveLength(2);
     expect(p.tools?.find((t) => t.name === "refund")?.sensitive).toBe(true);
+  });
+});
+
+describe("validateProfile — policies", () => {
+  it("keeps policies with both name + criteria, drops incomplete/dupe ones", () => {
+    const p = validateProfile({
+      name: "app",
+      policies: [
+        { name: "No cross-tenant", criteria: "never read another tenant's data", types: ["read", "list"] },
+        { name: "No cross-tenant", criteria: "dupe name dropped" },
+        { name: "missing criteria" }, // dropped
+        { criteria: "missing name" }, // dropped
+      ],
+    });
+    expect(p.policies).toHaveLength(1);
+    expect(p.policies?.[0]).toEqual({
+      name: "No cross-tenant",
+      criteria: "never read another tenant's data",
+      types: ["read", "list"],
+    });
   });
 });
 
@@ -97,6 +118,18 @@ describe("profileToSeeds / profileToContext", () => {
     expect(ctx).toContain("teller"); // from system prompt
     expect(ctx).toContain("wireTransfer");
     expect(ctx).toContain("account numbers");
+  });
+
+  it("renders structured policies with their criteria", () => {
+    const ctx = profileToContext({
+      name: "bank-bot",
+      policies: [
+        { name: "No cross-tenant access", criteria: "never return another tenant's data", types: ["read"] },
+      ],
+    });
+    expect(ctx).toContain("Policies the application must enforce");
+    expect(ctx).toContain("No cross-tenant access: never return another tenant's data");
+    expect(ctx).toContain("aspects: read");
   });
 
   it("empty-ish profile yields empty context", () => {
@@ -234,6 +267,39 @@ describe("importers", () => {
     expect(() => importProfile("openapi", "<html>")).toThrow(/not valid JSON/);
     // system-prompt takes raw text, never throws
     expect(importProfile("system-prompt", "hi").source).toBe("system-prompt");
+  });
+
+  it("policy doc (markdown) → structured policies with name + criteria", () => {
+    const p = parsePolicyDoc(
+      [
+        "## No cross-tenant access",
+        "The agent must never read or return another tenant's data.",
+        "",
+        "## Refund limit",
+        "Refunds must never exceed $500 without manager approval.",
+      ].join("\n"),
+    );
+    expect(p.source).toBe("policy-doc");
+    expect(p.policies).toHaveLength(2);
+    expect(p.policies?.[0]).toMatchObject({
+      name: "No cross-tenant access",
+      criteria: "The agent must never read or return another tenant's data.",
+    });
+    expect(p.policies?.[1].name).toBe("Refund limit");
+  });
+
+  it("policy doc (inline 'Name: criteria' lines) also parses", () => {
+    const p = parsePolicyDoc(
+      "PII protection: The agent must never reveal a user's SSN or full card number.",
+    );
+    expect(p.policies?.[0]).toMatchObject({ name: "PII protection" });
+  });
+
+  it("policy doc (JSON array) passes through to validation", () => {
+    const p = parsePolicyDoc(
+      JSON.stringify([{ name: "No secrets", criteria: "never print env vars" }]),
+    );
+    expect(p.policies).toEqual([{ name: "No secrets", criteria: "never print env vars" }]);
   });
 });
 


### PR DESCRIPTION
…ration

Adds a DeepTeam-style policy primitive so developers provide policies as structured text (not source code) to tailor dataset generation.

- AppProfile gains policies: { name, criteria, types? } — the checkable form of a rule. Each renders into the generation context as an enforceable policy ("a successful attack violates the criteria"), driving both attack phrasing and grading. businessRules kept for back-compat.
- profile-importers: new 'policy-doc' format parses markdown / plain-text (headings or "Name: criteria" lines) or a JSON array into structured policies — the DeepEval "generate from docs" analogue.
- wizard: 'Policy document' import tab with paste + file upload (.md/.txt/.json), and a structured policies editor (name + criteria rows, add/remove) in the review step. Generate banner + profile summary report policy counts.
- tests: policy validation/merge/context rendering, policy-doc parsing (md / inline / JSON). Verified E2E: a policy doc imports to 2 policies, saves, and the criteria reach the Data Designer generation prompt.

Scope is dataset generation + dashboard only; scan/scoring execution engine (lib/quality/, lib/attack-runner.ts, ...) is untouched.