### PR TITLE
feat(datasets): live row-by-row streaming for OpenAI-direct generation

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -54,7 +54,12 @@ import {
   type ImportFormat,
 } from "../lib/dataset/profile-importers.js";
 import { mergeSeeds } from "../lib/dataset/seed-from-analysis.js";
-import { recordsToRows, recordsToQualityRows } from "../lib/dataset/map-records.js";
+import {
+  recordsToRows,
+  recordsToQualityRows,
+  recordToRow,
+  recordToQualityRow,
+} from "../lib/dataset/map-records.js";
 import { validateRows, validateQualityRows, formatHistogram } from "../lib/dataset/validate.js";
 import { buildRegressionRow, appendRow, type PromoteInput } from "../lib/dataset/promote.js";
 import type { DatasetPreset, DatasetRow } from "../lib/dataset/types.js";
@@ -1746,6 +1751,7 @@ const server = createServer(
         res.end(JSON.stringify({ error: "Too many requests.", retryAfterSec }));
         return;
       }
+      let streamStarted = false;
       try {
         const repoRoot = join(import.meta.dirname, "..");
         const body = JSON.parse(await readBody(req)) as {
@@ -1765,6 +1771,8 @@ const server = createServer(
           maxTurns?: number;
           /** "data-designer" (default) or "openai" (call OpenAI directly). */
           backend?: "data-designer" | "openai";
+          /** Stream row-by-row NDJSON progress (OpenAI-direct only). */
+          stream?: boolean;
         };
         if (!body.preset || !body.out) {
           res.writeHead(400, { "Content-Type": "application/json" });
@@ -1895,9 +1903,45 @@ const server = createServer(
         // service); "data-designer" (default) posts to the NeMo microservice.
         // Same config in, same records out — everything else is unchanged.
         const backend = body.backend === "openai" ? "openai" : "data-designer";
+
+        // Live streaming (OpenAI-direct only — Data Designer returns a batch).
+        // Emits NDJSON: {type:"row",...} per generated row, then a final
+        // {type:"done",...} or {type:"error",...}.
+        const streaming = backend === "openai" && body.stream === true;
+        if (streaming) {
+          res.writeHead(200, {
+            "Content-Type": "application/x-ndjson",
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+          });
+          res.write(
+            JSON.stringify({ type: "start", total: preset.count ?? 300, backend }) + "\n",
+          );
+        }
+        streamStarted = streaming;
+
         let records;
         if (backend === "openai") {
-          records = await generateWithOpenAI(ddConfig, preset.count ?? 300);
+          records = await generateWithOpenAI(ddConfig, preset.count ?? 300, {
+            onRow: streaming
+              ? (rec, index, total) => {
+                  const row =
+                    kind === "quality"
+                      ? recordToQualityRow(rec)
+                      : recordToRow(rec, preset.family);
+                  res.write(
+                    JSON.stringify({
+                      type: "row",
+                      index,
+                      total,
+                      category: String(row.category ?? row.task ?? ""),
+                      severity: row.severity ? String(row.severity) : undefined,
+                      preview: String(row.prompt ?? row.input ?? "").slice(0, 160),
+                    }) + "\n",
+                  );
+                }
+              : undefined,
+          });
         } else {
           const client = new NemoDataDesignerClient();
           records = await client.generate(ddConfig, preset.count);
@@ -1908,38 +1952,63 @@ const server = createServer(
             : validateRows(recordsToRows(records, preset.family));
 
         if (errors.length > 0 || valid.length === 0) {
-          res.writeHead(422, { "Content-Type": "application/json" });
-          res.end(
-            JSON.stringify({
-              error: "generation produced invalid or zero rows",
-              invalid: errors.length,
-              kept: valid.length,
-              sampleErrors: errors.slice(0, 10),
-            }),
-          );
+          const payload = {
+            error: "generation produced invalid or zero rows",
+            invalid: errors.length,
+            kept: valid.length,
+            sampleErrors: errors.slice(0, 10),
+          };
+          if (streaming) {
+            res.write(JSON.stringify({ type: "error", ...payload }) + "\n");
+            res.end();
+          } else {
+            res.writeHead(422, { "Content-Type": "application/json" });
+            res.end(JSON.stringify(payload));
+          }
           return;
         }
 
         mkdirSync(dirname(outAbs), { recursive: true });
         writeFileSync(outAbs, JSON.stringify(valid, null, 2) + "\n", "utf-8");
 
-        res.writeHead(201, { "Content-Type": "application/json" });
-        res.end(
-          JSON.stringify({
-            out: body.out,
-            rowCount: valid.length,
-            duplicatesDropped,
-            histogram,
-            summary: formatHistogram(histogram),
-            backend,
-            ...(seedInfo ? { seeds: seedInfo } : {}),
-            ...(profileInfo ? { profile: profileInfo } : {}),
-            ...(preset.turnMode === "multi"
-              ? { turnMode: "multi", maxTurns: Math.min(8, Math.max(2, preset.maxTurns ?? 3)) }
-              : {}),
-          }),
-        );
+        const result = {
+          out: body.out,
+          rowCount: valid.length,
+          duplicatesDropped,
+          histogram,
+          summary: formatHistogram(histogram),
+          backend,
+          ...(seedInfo ? { seeds: seedInfo } : {}),
+          ...(profileInfo ? { profile: profileInfo } : {}),
+          ...(preset.turnMode === "multi"
+            ? { turnMode: "multi", maxTurns: Math.min(8, Math.max(2, preset.maxTurns ?? 3)) }
+            : {}),
+        };
+        if (streaming) {
+          res.write(JSON.stringify({ type: "done", ...result }) + "\n");
+          res.end();
+        } else {
+          res.writeHead(201, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(result));
+        }
       } catch (err) {
+        // If the stream already started, headers are sent — emit an error event
+        // rather than trying to set a status code.
+        if (streamStarted) {
+          try {
+            res.write(
+              JSON.stringify({
+                type: "error",
+                error: "dataset generation failed",
+                detail: formatErrorDetails(err),
+              }) + "\n",
+            );
+          } catch {
+            /* client already gone */
+          }
+          res.end();
+          return;
+        }
         // Fail-soft messaging: Data Designer down / no creds is the common case.
         const ddUrl = process.env.NEMO_DATA_DESIGNER_URL;
         res.writeHead(502, { "Content-Type": "application/json" });

--- a/dashboard/ui/src/api/datasets.ts
+++ b/dashboard/ui/src/api/datasets.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "./client";
+import { apiFetch, apiStream } from "./client";
 
 export interface DatasetSummary {
   path: string;
@@ -133,6 +133,56 @@ export function generateDataset(body: GenerateDatasetRequest) {
     method: "POST",
     body: JSON.stringify(body),
   });
+}
+
+// --- streaming generation (OpenAI-direct) ---
+
+export type GenerateStreamEvent =
+  | { type: "start"; total: number; backend: string }
+  | {
+      type: "row";
+      index: number;
+      total: number;
+      category: string;
+      severity?: string;
+      preview: string;
+    }
+  | ({ type: "done" } & GenerateDatasetResponse)
+  | { type: "error"; error: string; detail?: string; sampleErrors?: string[] };
+
+/**
+ * Generate with row-by-row NDJSON streaming. Calls `onEvent` for each event as
+ * it arrives; resolves when the stream ends. Falls back to a normal request if
+ * the server doesn't stream (older build).
+ */
+export async function generateDatasetStream(
+  body: GenerateDatasetRequest,
+  onEvent: (e: GenerateStreamEvent) => void,
+): Promise<void> {
+  const res = await apiStream("/api/datasets/generate", {
+    method: "POST",
+    body: JSON.stringify({ ...body, stream: true }),
+  });
+  if (!res.ok || !res.body) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`API error ${res.status}: ${text}`);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let nl: number;
+    while ((nl = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (line) onEvent(JSON.parse(line) as GenerateStreamEvent);
+    }
+  }
+  const tail = buf.trim();
+  if (tail) onEvent(JSON.parse(tail) as GenerateStreamEvent);
 }
 
 export interface EvalRunPoint {

--- a/dashboard/ui/src/pages/DatasetsPage/index.tsx
+++ b/dashboard/ui/src/pages/DatasetsPage/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import {
   listDatasets,
   generateDataset,
+  generateDatasetStream,
   listEvalRuns,
   listGenerationProviders,
   listProfiles,
@@ -162,6 +163,13 @@ export function DatasetsPage() {
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [ok, setOk] = useState<string | null>(null);
+  // Live streaming progress (OpenAI-direct).
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(
+    null,
+  );
+  const [liveRows, setLiveRows] = useState<
+    { category: string; severity?: string; preview: string }[]
+  >([]);
 
   const refresh = async () => {
     setLoading(true);
@@ -215,41 +223,72 @@ export function DatasetsPage() {
     }
   };
 
+  const okMessage = (res: {
+    rowCount: number;
+    out: string;
+    duplicatesDropped: number;
+    seeds?: { roles: number; surfaces: number };
+    profile?: { name: string; tools: number; policies: number; rules: number };
+    turnMode?: "multi";
+    maxTurns?: number;
+  }) => {
+    const seedNote = res.seeds
+      ? ` — seeded from analysis (${res.seeds.roles} roles, ${res.seeds.surfaces} surfaces)`
+      : "";
+    const profileNote = res.profile
+      ? ` — tailored to "${res.profile.name}" (${res.profile.tools} tools, ${res.profile.policies} policies, ${res.profile.rules} rules)`
+      : "";
+    const turnNote =
+      res.turnMode === "multi" ? ` — multi-turn (up to ${res.maxTurns} turns)` : "";
+    return `Generated ${res.rowCount} rows -> ${res.out} (dropped ${res.duplicatesDropped} duplicates)${seedNote}${profileNote}${turnNote}`;
+  };
+
   const onGenerate = async () => {
     setGenerating(true);
     setError(null);
     setOk(null);
+    setProgress(null);
+    setLiveRows([]);
+    const dir = kind === "quality" ? `quality-${family}` : `nemo-${family}`;
+    const body = {
+      preset: PRESETS[`${kind}-${family}`],
+      out: `data/datasets/${dir}/${outName.replace(/[^a-z0-9._-]/gi, "-")}.json`,
+      count,
+      backend,
+      provider: backend === "openai" ? "openai" : providerId,
+      ...(model.trim() ? { generationModel: model.trim() } : {}),
+      ...(profileId ? { profileId } : {}),
+      ...(turnMode === "multi" ? { turnMode: "multi" as const, maxTurns } : {}),
+      ...(seedConfigPath.trim() ? { seedConfigPath: seedConfigPath.trim() } : {}),
+    };
     try {
-      const dir = kind === "quality" ? `quality-${family}` : `nemo-${family}`;
-      const res = await generateDataset({
-        preset: PRESETS[`${kind}-${family}`],
-        out: `data/datasets/${dir}/${outName.replace(/[^a-z0-9._-]/gi, "-")}.json`,
-        count,
-        backend,
-        provider: backend === "openai" ? "openai" : providerId,
-        ...(model.trim() ? { generationModel: model.trim() } : {}),
-        ...(profileId ? { profileId } : {}),
-        ...(turnMode === "multi" ? { turnMode: "multi" as const, maxTurns } : {}),
-        ...(seedConfigPath.trim()
-          ? { seedConfigPath: seedConfigPath.trim() }
-          : {}),
-      });
-      const seedNote = res.seeds
-        ? ` — seeded from analysis (${res.seeds.roles} roles, ${res.seeds.surfaces} surfaces)`
-        : "";
-      const profileNote = res.profile
-        ? ` — tailored to "${res.profile.name}" (${res.profile.tools} tools, ${res.profile.policies} policies, ${res.profile.rules} rules)`
-        : "";
-      const turnNote =
-        res.turnMode === "multi" ? ` — multi-turn (up to ${res.maxTurns} turns)` : "";
-      setOk(
-        `Generated ${res.rowCount} rows -> ${res.out} (dropped ${res.duplicatesDropped} duplicates)${seedNote}${profileNote}${turnNote}`,
-      );
+      if (backend === "openai") {
+        // Stream row-by-row so results appear as they're generated.
+        let done = 0;
+        await generateDatasetStream(body, (e) => {
+          if (e.type === "start") setProgress({ done: 0, total: e.total });
+          else if (e.type === "row") {
+            done += 1;
+            setProgress({ done, total: e.total });
+            setLiveRows((rows) =>
+              [
+                { category: e.category, severity: e.severity, preview: e.preview },
+                ...rows,
+              ].slice(0, 8),
+            );
+          } else if (e.type === "done") setOk(okMessage(e));
+          else if (e.type === "error")
+            setError(`${e.error}${e.detail ? ` — ${e.detail}` : ""}`);
+        });
+      } else {
+        setOk(okMessage(await generateDataset(body)));
+      }
       await refresh();
     } catch (e) {
       setError((e as Error).message);
     } finally {
       setGenerating(false);
+      setProgress(null);
     }
   };
 
@@ -543,6 +582,45 @@ export function DatasetsPage() {
               </>
             )}
           </p>
+
+          {progress && (
+            <div className="rounded-lg border border-border p-3 space-y-2">
+              <div className="flex items-center justify-between text-xs">
+                <span className="flex items-center gap-1.5 text-foreground">
+                  <Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
+                  Generating with OpenAI…
+                </span>
+                <span className="font-mono text-muted-foreground">
+                  {progress.done} / {progress.total}
+                </span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full bg-primary transition-all"
+                  style={{
+                    width: `${progress.total ? (progress.done / progress.total) * 100 : 0}%`,
+                  }}
+                />
+              </div>
+              {liveRows.length > 0 && (
+                <div className="space-y-1 pt-1">
+                  {liveRows.map((r, i) => (
+                    <div
+                      key={`${progress.done}-${i}`}
+                      className="flex items-start gap-2 text-[11px] animate-in fade-in slide-in-from-top-1"
+                    >
+                      <Badge variant="secondary" className="shrink-0 text-[10px]">
+                        {r.category}
+                      </Badge>
+                      <span className="text-muted-foreground truncate">
+                        {r.preview}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
           {error && (
             <Alert variant="destructive">

--- a/lib/dataset/openai-generator.ts
+++ b/lib/dataset/openai-generator.ts
@@ -44,6 +44,8 @@ export interface OpenAiGeneratorOptions {
   concurrency?: number;
   /** Inject a chat implementation (tests / alternate providers). */
   chat?: ChatFn;
+  /** Called as each row completes (out of order) — for live streaming. */
+  onRow?: (record: NemoRecord, index: number, total: number) => void;
   signal?: AbortSignal;
 }
 
@@ -181,6 +183,8 @@ export async function generateWithOpenAI(
     });
     const grading = parseJsonObject(structRaw);
 
-    return { ...sample, [structCol.name]: grading } as NemoRecord;
+    const record = { ...sample, [structCol.name]: grading } as NemoRecord;
+    opts.onRow?.(record, i, rows.length);
+    return record;
   });
 }

--- a/tests/dataset-openai-generator.test.ts
+++ b/tests/dataset-openai-generator.test.ts
@@ -88,6 +88,21 @@ describe("generateWithOpenAI", () => {
     expect(rec.grading).toMatchObject({ reference: expect.any(String) });
   });
 
+  it("fires onRow for each completed row (for live streaming)", async () => {
+    const { chat } = stubChat();
+    const config = buildDataDesignerConfig({ family: "mcp", count: 5 });
+    const seen: { index: number; total: number; hasPrompt: boolean }[] = [];
+    await generateWithOpenAI(config, 5, {
+      chat,
+      concurrency: 2,
+      onRow: (rec, index, total) =>
+        seen.push({ index, total, hasPrompt: typeof (rec as Record<string, unknown>).prompt === "string" }),
+    });
+    expect(seen).toHaveLength(5);
+    expect(seen.every((s) => s.total === 5 && s.hasPrompt)).toBe(true);
+    expect(new Set(seen.map((s) => s.index)).size).toBe(5); // each row once
+  });
+
   it("throws without an API key and without an injected chat", async () => {
     const prev = process.env.OPENAI_API_KEY;
     delete process.env.OPENAI_API_KEY;


### PR DESCRIPTION
Instead of a spinner until the whole batch finishes, rows now appear as they're generated. Uses the app's existing NDJSON streaming pattern.

- openai-generator: onRow(record, index, total) callback, fired as each row completes in the concurrency pool.
- server: generate accepts stream:true (OpenAI-direct only — Data Designer returns a batch). Emits NDJSON: {type:"start"} → {type:"row", index, total, category, severity, preview} per row → {type:"done", ...result} (or {type:"error"}). Errors after the stream opens are emitted as events, not a status code.
- ui: generateDatasetStream() reads the NDJSON; the Datasets page shows a live progress bar (done/total) and the last few row previews as they stream in. Data Designer path keeps the plain request.
- tests: onRow fires once per row with the right total.

Verified with live OpenAI: start → 5 rows streaming in as they complete (out of order via the pool) → done, and the browser progress UI updating live. Scan/scoring engine untouched.