### PR TITLE
feat(datasets): "Use for evaluation" — one click from dataset to a scan

### DIFF
--- a/dashboard/ui/src/pages/DatasetsPage/index.tsx
+++ b/dashboard/ui/src/pages/DatasetsPage/index.tsx
@@ -35,6 +35,7 @@ import {
   Wand2,
   ChevronRight,
   ChevronDown,
+  ArrowRight,
 } from "lucide-react";
 
 const PRESETS: Record<string, string> = {
@@ -192,6 +193,7 @@ function RowItem({ row }: { row: DatasetRow }) {
 
 /** A dataset summary card that expands to show its rows on demand. */
 function DatasetCard({ d }: { d: DatasetSummary }) {
+  const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const [rows, setRows] = useState<DatasetRow[] | null>(null);
   const [total, setTotal] = useState(0);
@@ -242,14 +244,28 @@ function DatasetCard({ d }: { d: DatasetSummary }) {
             )}
           </div>
         </div>
-        <Button size="sm" variant="outline" onClick={toggle} className="shrink-0">
-          {open ? (
-            <ChevronDown className="w-3.5 h-3.5" />
-          ) : (
-            <ChevronRight className="w-3.5 h-3.5" />
+        <div className="flex flex-col items-end gap-1.5 shrink-0">
+          {d.kind !== "quality" && (
+            <Button
+              size="sm"
+              onClick={() =>
+                navigate(`/new-scan?dataset=${encodeURIComponent(d.path)}`)
+              }
+              title="Launch a scan using this dataset as the attack set"
+            >
+              Use for evaluation
+              <ArrowRight className="w-3.5 h-3.5" />
+            </Button>
           )}
-          View rows
-        </Button>
+          <Button size="sm" variant="outline" onClick={toggle}>
+            {open ? (
+              <ChevronDown className="w-3.5 h-3.5" />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5" />
+            )}
+            View rows
+          </Button>
+        </div>
       </div>
       {open && (
         <div className="border-t border-border p-3 space-y-2 max-h-96 overflow-y-auto">

--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -292,7 +292,11 @@ export default function NewScanPage() {
   const [policyUploadError, setPolicyUploadError] = useState<string | null>(null);
 
   // ── Evaluation dataset (customAttacksFile) ──
-  const [datasetFile, setDatasetFile] = useState("");
+  // Deep link from the Datasets tab ("Use for evaluation"): ?dataset=<path>
+  // preselects the dataset and opens the section.
+  const deepLinkDataset =
+    new URLSearchParams(location.search).get("dataset") || "";
+  const [datasetFile, setDatasetFile] = useState(deepLinkDataset);
   const [datasetOnly, setDatasetOnly] = useState(false);
   const [availableDatasets, setAvailableDatasets] = useState<DatasetSummary[]>([]);
 
@@ -1734,7 +1738,11 @@ export default function NewScanPage() {
             </div>
           </CollapsibleSection>
 
-          <CollapsibleSection title="Evaluation Dataset" icon={FileText}>
+          <CollapsibleSection
+            title="Evaluation Dataset"
+            icon={FileText}
+            defaultOpen={!!deepLinkDataset}
+          >
             <div className="space-y-4">
               <FieldRow
                 label="Attack dataset"


### PR DESCRIPTION
Closes the gap between generating a dataset and running it. Previously you had to leave the Datasets tab, go to Launch Scan, open the collapsed "Evaluation Dataset" section, and pick the dataset by hand.

- Datasets tab: each security dataset card gets a "Use for evaluation →" button that deep-links to /new-scan?dataset=<path>. (Quality datasets omit it — the scan UI doesn't run them.)
- Launch Scan: reads the ?dataset= param, preselects it as the attack set (customAttacksFile), and auto-opens the Evaluation Dataset section so it's visible.

UI-only; no scan/scoring engine changes. Verified end-to-end in the browser: "Use for evaluation" → Launch Scan opens with the section expanded and the dataset selected, ready to Start Scan.