### PR TITLE
feat(datasets): custom focus tasks for quality datasets (type-and-add)

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -37,6 +37,7 @@ import { defaultCategoryPool } from "../lib/dataset/category-set.js";
 import {
   defaultQualityPool,
   QUALITY_METRICS,
+  resolveQualityPool,
 } from "../lib/dataset/quality-set.js";
 import { NemoDataDesignerClient } from "../lib/dataset/nemo-client.js";
 import { generateWithOpenAI } from "../lib/dataset/openai-generator.js";
@@ -1694,7 +1695,23 @@ const server = createServer(
         }
         const rows = Array.isArray(body.rows) ? body.rows : [];
         const kind = body.kind === "quality" ? "quality" : "security";
-        const gen = kind === "quality" ? validateQualityRows(rows) : validateRows(rows);
+        // Curated rows already passed generation validation; allow whatever
+        // (possibly custom) task labels they carry so a save/top-up preserves
+        // them. `metric` still validates strictly.
+        const allowedTasks =
+          kind === "quality"
+            ? rows
+                .map((r) =>
+                  r && typeof r === "object"
+                    ? String((r as Record<string, unknown>).task ?? "").trim()
+                    : "",
+                )
+                .filter(Boolean)
+            : [];
+        const gen =
+          kind === "quality"
+            ? validateQualityRows(rows, { allowedTasks })
+            : validateRows(rows);
         if (gen.errors.length > 0 || gen.valid.length === 0) {
           res.writeHead(422, {
             "Content-Type": "application/json",
@@ -1723,7 +1740,7 @@ const server = createServer(
           } catch {
             /* unreadable existing file — treat as fresh write */
           }
-          const merged = mergeDatasets(kind, existingRows, gen.valid);
+          const merged = mergeDatasets(kind, existingRows, gen.valid, { allowedTasks });
           added = merged.added;
           duplicatesDropped += gen.valid.length - merged.added;
           valid = merged.valid;
@@ -2204,9 +2221,21 @@ const server = createServer(
         }
 
         const kind = preset.kind ?? "security";
+        // Quality datasets may carry user-defined custom focus tasks (a quality
+        // row's `task` is a report label, not a routing key — grading is on
+        // `metric`). Resolve the pool with allowCustom so custom slugs pass, and
+        // remember them as the validation allow-list. Security categories stay
+        // fixed (the red-team engine routes on them), so no custom path there.
+        let allowedTasks: string[] = [];
+        if (kind === "quality" && Array.isArray(preset.tasks) && preset.tasks.length) {
+          preset.tasks = resolveQualityPool(preset.family, preset.tasks, {
+            allowCustom: true,
+          });
+          allowedTasks = preset.tasks;
+        }
         const ddConfig =
           kind === "quality"
-            ? buildQualityDataDesignerConfig(preset, seeds)
+            ? buildQualityDataDesignerConfig(preset, seeds, { allowCustomTasks: true })
             : buildDataDesignerConfig(preset, seeds);
 
         // Generation backend: a direct LLM engine (openai | anthropic |
@@ -2263,7 +2292,7 @@ const server = createServer(
         // Validate the freshly generated rows (the quality gate is on these).
         const gen =
           kind === "quality"
-            ? validateQualityRows(recordsToQualityRows(records))
+            ? validateQualityRows(recordsToQualityRows(records), { allowedTasks })
             : validateRows(recordsToRows(records, preset.family));
         const errors = gen.errors;
         let valid: unknown[] = gen.valid;
@@ -2300,7 +2329,7 @@ const server = createServer(
           } catch {
             /* unreadable existing file — treat as fresh write */
           }
-          const merged = mergeDatasets(kind, existingRows, valid);
+          const merged = mergeDatasets(kind, existingRows, valid, { allowedTasks });
           addedCount = merged.added;
           duplicatesDropped += valid.length - merged.added;
           valid = merged.valid;

--- a/dashboard/ui/src/pages/DatasetsPage/index.tsx
+++ b/dashboard/ui/src/pages/DatasetsPage/index.tsx
@@ -400,6 +400,10 @@ export function DatasetsPage() {
   const [taxonomy, setTaxonomy] = useState<DatasetTaxonomy | null>(null);
   const [selCategories, setSelCategories] = useState<string[]>([]);
   const [selSeverities, setSelSeverities] = useState<string[]>([]);
+  // User-defined focus tasks (quality datasets only — a quality row's task is a
+  // report label, so custom ones are safe; security categories stay fixed).
+  const [customTasks, setCustomTasks] = useState<string[]>([]);
+  const [taskDraft, setTaskDraft] = useState("");
   // Curate-before-save: generate into a review list, keep the good rows.
   const [reviewMode, setReviewMode] = useState(false);
   const [curate, setCurate] = useState<
@@ -465,7 +469,35 @@ export function DatasetsPage() {
       .catch(() => setTaxonomy(null));
     setSelCategories([]);
     setSelSeverities([]);
+    setCustomTasks([]);
+    setTaskDraft("");
   }, [kind, family]);
+
+  // Add the current draft (or comma-separated drafts) as custom focus tasks.
+  const addCustomTasks = (raw: string) => {
+    const slugs = raw
+      .split(",")
+      .map((s) =>
+        s
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "_")
+          .replace(/^_+|_+$/g, "")
+          .slice(0, 40)
+          .replace(/_+$/g, ""),
+      )
+      .filter(Boolean);
+    if (!slugs.length) return;
+    const taxonomyTasks = new Set(taxonomy?.tasks ?? []);
+    setCustomTasks((prev) => {
+      const next = [...prev];
+      for (const s of slugs) {
+        if (!taxonomyTasks.has(s) && !next.includes(s)) next.push(s);
+      }
+      return next;
+    });
+    setTaskDraft("");
+  };
 
   // Live cost estimate — debounced so typing in the count field doesn't spam
   // the endpoint. Cleared on unmount / dependency change.
@@ -588,7 +620,9 @@ export function DatasetsPage() {
       ...(append && !isPreview ? { append: true } : {}),
       ...(kind === "security" && selCategories.length ? { categories: selCategories } : {}),
       ...(kind === "security" && selSeverities.length ? { severities: selSeverities } : {}),
-      ...(kind === "quality" && selCategories.length ? { tasks: selCategories } : {}),
+      ...(kind === "quality" && (selCategories.length || customTasks.length)
+        ? { tasks: [...selCategories, ...customTasks] }
+        : {}),
       ...(kind === "quality" && selSeverities.length ? { metrics: selSeverities } : {}),
       ...(seedConfigPath.trim() ? { seedConfigPath: seedConfigPath.trim() } : {}),
     };
@@ -929,7 +963,9 @@ export function DatasetsPage() {
                   <div className="space-y-1">
                     <span className="text-[11px] text-muted-foreground">
                       {primaryLabel}
-                      {selCategories.length ? ` (${selCategories.length} selected)` : " (all)"}
+                      {selCategories.length || customTasks.length
+                        ? ` (${selCategories.length + customTasks.length} selected)`
+                        : " (all)"}
                     </span>
                     <div className="flex flex-wrap gap-1">
                       {primary.map((c) => (
@@ -946,7 +982,58 @@ export function DatasetsPage() {
                           </Badge>
                         </button>
                       ))}
+                      {kind === "quality" &&
+                        customTasks.map((c) => (
+                          <button
+                            key={c}
+                            type="button"
+                            title="Remove custom task"
+                            onClick={() =>
+                              setCustomTasks((prev) => prev.filter((t) => t !== c))
+                            }
+                          >
+                            <Badge
+                              variant="default"
+                              className="cursor-pointer text-[10px] gap-0.5"
+                            >
+                              {c}
+                              <span className="opacity-70">×</span>
+                            </Badge>
+                          </button>
+                        ))}
                     </div>
+                    {kind === "quality" && (
+                      <div className="flex items-center gap-1.5 pt-1">
+                        <Input
+                          className="h-7 text-xs max-w-64"
+                          placeholder="Add your own task, e.g. refund_policy_qa — Enter"
+                          value={taskDraft}
+                          onChange={(e) => setTaskDraft(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === ",") {
+                              e.preventDefault();
+                              addCustomTasks(taskDraft);
+                            }
+                          }}
+                        />
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7"
+                          disabled={!taskDraft.trim()}
+                          onClick={() => addCustomTasks(taskDraft)}
+                        >
+                          Add
+                        </Button>
+                      </div>
+                    )}
+                    {kind === "quality" && (
+                      <p className="text-[10px] text-muted-foreground">
+                        Custom tasks let you focus a functional/agent eval on your
+                        own scenarios. (Security categories are fixed — the
+                        red-team engine routes on them.)
+                      </p>
+                    )}
                   </div>
                   <div className="space-y-1">
                     <span className="text-[11px] text-muted-foreground">

--- a/lib/dataset/quality-config-builder.ts
+++ b/lib/dataset/quality-config-builder.ts
@@ -134,8 +134,11 @@ function referenceTemplate(context?: string): string {
 export function buildQualityDataDesignerConfig(
   preset: DatasetPreset,
   seeds?: DatasetSeeds,
+  opts?: { allowCustomTasks?: boolean },
 ): DataDesignerConfig {
-  const tasks = resolveQualityPool(preset.family, preset.tasks);
+  const tasks = resolveQualityPool(preset.family, preset.tasks, {
+    allowCustom: opts?.allowCustomTasks,
+  });
   const metrics = preset.metrics ?? defaultMetrics(preset.family);
   const roles = seeds?.roles ?? preset.roles ?? DEFAULT_ROLES;
   const surfaces = seeds?.surfaces ?? preset.surfaces ?? DEFAULT_SURFACES;

--- a/lib/dataset/quality-set.ts
+++ b/lib/dataset/quality-set.ts
@@ -74,14 +74,47 @@ export function defaultQualityPool(family: DatasetFamily): string[] {
 }
 
 /**
- * Resolve a preset's quality task list, fail-closed on unknown tasks (mirrors
- * the security `resolveCategoryPool` contract).
+ * Normalize a user-supplied custom task label to a safe slug (lowercase,
+ * underscore-separated, ≤40 chars), or null if it reduces to nothing. Custom
+ * tasks are allowed for QUALITY datasets only — a quality row's `task` is a
+ * report label the scorer buckets by; grading keys off `metric`, so a custom
+ * task can't misroute or mis-grade. (Security `category` is different: the
+ * red-team engine routes on it, so those stay fixed to the taxonomy.)
+ */
+export function sanitizeCustomTask(s: string): string | null {
+  const slug = String(s ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 40)
+    .replace(/_+$/g, "");
+  return slug || null;
+}
+
+/**
+ * Resolve a preset's quality task list. Fail-closed on unknown tasks by default
+ * (mirrors the security `resolveCategoryPool` contract). With `allowCustom`,
+ * unknown tasks are kept as sanitized slugs instead of throwing — this is how
+ * user-defined focus tasks (for non-security agent evals) flow through.
  */
 export function resolveQualityPool(
   family: DatasetFamily,
   requested: string[] | undefined,
+  opts?: { allowCustom?: boolean },
 ): string[] {
   if (!requested || requested.length === 0) return defaultQualityPool(family);
+  if (opts?.allowCustom) {
+    const out: string[] = [];
+    for (const t of requested) {
+      if (isQualityTask(t)) out.push(t);
+      else {
+        const slug = sanitizeCustomTask(t);
+        if (slug) out.push(slug);
+      }
+    }
+    return out.length ? [...new Set(out)] : defaultQualityPool(family);
+  }
   const unknown = requested.filter((t) => !isQualityTask(t));
   if (unknown.length > 0) {
     throw new Error(

--- a/lib/dataset/validate.ts
+++ b/lib/dataset/validate.ts
@@ -116,11 +116,21 @@ export interface QualityValidationResult {
  * `input` non-empty, and at least one of `reference` / `expectedTools` present
  * (a row with no grading reference can't be scored).
  */
-export function validateQualityRows(rows: unknown[]): QualityValidationResult {
+/**
+ * @param opts.allowedTasks extra task labels accepted beyond the known pool —
+ *   user-defined custom focus tasks (quality datasets only). A row's `task` is
+ *   valid if it's a known QualityTask OR listed here. `metric` stays strict
+ *   because the scorer grades on it.
+ */
+export function validateQualityRows(
+  rows: unknown[],
+  opts?: { allowedTasks?: Iterable<string> },
+): QualityValidationResult {
   const valid: QualityRow[] = [];
   const errors: string[] = [];
   const histogram: Record<string, number> = {};
   const seen = new Set<string>();
+  const allowedTasks = new Set(opts?.allowedTasks ?? []);
   let duplicatesDropped = 0;
 
   rows.forEach((raw, i) => {
@@ -138,7 +148,7 @@ export function validateQualityRows(rows: unknown[]): QualityValidationResult {
       ? (o.expectedTools as unknown[]).map((t) => String(t).trim()).filter(Boolean)
       : [];
 
-    if (!isQualityTask(task)) {
+    if (!isQualityTask(task) && !allowedTasks.has(task)) {
       errors.push(`row ${idx}: unknown quality task "${task}"`);
       return;
     }
@@ -189,11 +199,26 @@ export function mergeDatasets(
   kind: "security" | "quality",
   existing: unknown[],
   incoming: unknown[],
+  opts?: { allowedTasks?: Iterable<string> },
 ): (ValidationResult | QualityValidationResult) & { added: number } {
-  const existingCount = Array.isArray(existing) ? existing.length : 0;
-  const combined = [...(Array.isArray(existing) ? existing : []), ...incoming];
-  const res =
-    kind === "quality" ? validateQualityRows(combined) : validateRows(combined);
+  const existingArr = Array.isArray(existing) ? existing : [];
+  const existingCount = existingArr.length;
+  const combined = [...existingArr, ...incoming];
+  let res: ValidationResult | QualityValidationResult;
+  if (kind === "quality") {
+    // Existing rows were valid when saved — keep any custom task labels they
+    // already carry so a top-up never drops what's already on disk.
+    const allowed = new Set(opts?.allowedTasks ?? []);
+    for (const r of existingArr) {
+      if (r && typeof r === "object") {
+        const t = String((r as Record<string, unknown>).task ?? "").trim();
+        if (t) allowed.add(t);
+      }
+    }
+    res = validateQualityRows(combined, { allowedTasks: allowed });
+  } else {
+    res = validateRows(combined);
+  }
   return { ...res, added: res.valid.length - existingCount };
 }
 

--- a/tests/dataset-merge.test.ts
+++ b/tests/dataset-merge.test.ts
@@ -49,4 +49,20 @@ describe("mergeDatasets (append / top-up)", () => {
     expect(res.valid).toHaveLength(2);
     expect(res.added).toBe(1);
   });
+
+  it("preserves existing custom-task rows on a top-up (auto allow-list)", () => {
+    // A row saved earlier with a custom task label.
+    const existing = [
+      { ...qrow("what is your refund window?"), task: "refund_policy_qa" },
+    ];
+    // New rows carry the same custom task; caller passes it as allowed.
+    const incoming = [
+      { ...qrow("how long to get a refund?"), task: "refund_policy_qa" },
+    ];
+    const res = mergeDatasets("quality", existing, incoming, {
+      allowedTasks: ["refund_policy_qa"],
+    });
+    expect(res.valid).toHaveLength(2); // existing custom-task row survives
+    expect(res.added).toBe(1);
+  });
 });

--- a/tests/dataset-quality.test.ts
+++ b/tests/dataset-quality.test.ts
@@ -6,6 +6,7 @@ import {
   defaultQualityPool,
   isQualityMetric,
   isQualityTask,
+  sanitizeCustomTask,
 } from "../lib/dataset/quality-set.js";
 import { validateQualityRows } from "../lib/dataset/validate.js";
 import { buildQualityDataDesignerConfig } from "../lib/dataset/quality-config-builder.js";
@@ -22,6 +23,22 @@ describe("quality-set", () => {
   });
   it("resolveQualityPool rejects unknown tasks (fail-closed)", () => {
     expect(() => resolveQualityPool("mcp", ["not_a_task"])).toThrow(/unknown tasks/);
+  });
+  it("resolveQualityPool keeps custom tasks as sanitized slugs with allowCustom", () => {
+    const pool = resolveQualityPool(
+      "mcp",
+      ["tool_selection", "Refund Policy QA!", "  "],
+      { allowCustom: true },
+    );
+    expect(pool).toContain("tool_selection"); // known task preserved
+    expect(pool).toContain("refund_policy_qa"); // custom normalized
+    expect(pool).not.toContain(""); // blank dropped
+  });
+  it("sanitizeCustomTask normalizes to a safe slug (or null)", () => {
+    expect(sanitizeCustomTask("Refund Policy QA")).toBe("refund_policy_qa");
+    expect(sanitizeCustomTask("  billing/disputes  ")).toBe("billing_disputes");
+    expect(sanitizeCustomTask("!!!")).toBeNull();
+    expect(sanitizeCustomTask("")).toBeNull();
   });
   it("knows its metrics", () => {
     expect(isQualityMetric("tool_call_accuracy")).toBe(true);
@@ -46,6 +63,20 @@ describe("validateQualityRows (fail-closed)", () => {
   it("rejects unknown task / metric", () => {
     expect(validateQualityRows([{ ...good, task: "bogus" }]).errors[0]).toMatch(/unknown quality task/);
     expect(validateQualityRows([{ ...good, metric: "bogus" }]).errors[0]).toMatch(/unknown metric/);
+  });
+  it("accepts a custom task when allow-listed, but still rejects a bad metric", () => {
+    const row = { ...good, task: "refund_policy_qa" };
+    // Without the allow-list, the custom task is rejected (fail-closed default).
+    expect(validateQualityRows([row]).errors[0]).toMatch(/unknown quality task/);
+    // With it allow-listed, the row passes.
+    const ok = validateQualityRows([row], { allowedTasks: ["refund_policy_qa"] });
+    expect(ok.errors).toEqual([]);
+    expect(ok.valid[0].task).toBe("refund_policy_qa");
+    // metric stays strict even with a custom task allowed.
+    const badMetric = validateQualityRows([{ ...row, metric: "bogus" }], {
+      allowedTasks: ["refund_policy_qa"],
+    });
+    expect(badMetric.errors[0]).toMatch(/unknown metric/);
   });
   it("rejects a row with no reference and no expectedTools", () => {
     const r = validateQualityRows([{ task: "rag_answer", input: "q?", metric: "faithfulness" }]);


### PR DESCRIPTION
Lets users define their own focus tasks for functional/agent evals — type a label, Enter (or comma) to add, multiple chips, removable. For the "eval an agent that isn't security-focused" case where the built-in task taxonomy doesn't fit.

Safe because a quality row's `task` is a report label the scorer buckets by — grading keys off `metric`, which stays strictly validated. Custom tasks are sanitized to slugs (lowercase, underscores, ≤40 chars) and threaded through:
  - resolveQualityPool(..., {allowCustom}) keeps them as sampler values
  - validateQualityRows(..., {allowedTasks}) accepts them (metric still strict)
  - mergeDatasets auto-allows existing rows' tasks so a top-up never drops them

Security categories deliberately stay fixed to the taxonomy: the red-team engine routes on `category` and coerces unknowns to prompt_injection, so a custom security category would silently misroute. The UI custom-add input is shown for quality only, with a note explaining why. Scan engine untouched.