### PR TITLE
Persist generated datasets (Postgres table + PVC fallback)

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -83,6 +83,12 @@ import {
 import { estimateCost } from "../lib/dataset/cost-estimate.js";
 import { runQualityEval } from "../lib/quality/scorer.js";
 import {
+  listDatasetsStore,
+  readDatasetRowsStore,
+  datasetExistsStore,
+  saveDatasetStore,
+} from "../lib/dataset/dataset-store.js";
+import {
   exportDataset,
   exportContentType,
   isExportFormat,
@@ -1634,19 +1640,14 @@ const server = createServer(
           return;
         }
 
-        let existing: DatasetRow[] = [];
-        if (existsSync(outAbs)) {
-          try {
-            const raw = JSON.parse(readFileSync(outAbs, "utf-8"));
-            if (Array.isArray(raw)) existing = raw as DatasetRow[];
-          } catch {
-            /* treat unreadable as empty; we overwrite with a valid array */
-          }
-        }
+        const tenant = ctx?.tenantId ?? "";
+        const existingRaw = await readDatasetRowsStore(tenant, out);
+        const existing = Array.isArray(existingRaw)
+          ? (existingRaw as DatasetRow[])
+          : [];
         const { rows, added } = appendRow(existing, valid[0]);
         if (added) {
-          mkdirSync(dirname(outAbs), { recursive: true });
-          writeFileSync(outAbs, JSON.stringify(rows, null, 2) + "\n", "utf-8");
+          await saveDatasetStore(tenant, out, rows);
         }
         res.writeHead(added ? 201 : 200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ out, added, rowCount: rows.length }));
@@ -1660,7 +1661,7 @@ const server = createServer(
     // API: list generated eval datasets (data/datasets/**) with stats
     if (url.pathname === "/api/datasets" && req.method === "GET") {
       try {
-        const datasets = listDatasets(join(import.meta.dirname, ".."));
+        const datasets = await listDatasetsStore(ctx?.tenantId ?? "");
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ datasets }));
       } catch (err) {
@@ -1727,28 +1728,23 @@ const server = createServer(
           );
           return;
         }
-        // Top-up: merge into the existing file, deduping across both sets.
+        // Top-up: merge into the existing dataset, deduping across both sets.
+        const tenant = ctx?.tenantId ?? "";
         let valid: unknown[] = gen.valid;
         let histogram = gen.histogram;
         let duplicatesDropped = gen.duplicatesDropped;
         let added = gen.valid.length;
-        const append = body.append === true && existsSync(outAbs);
+        const append =
+          body.append === true && (await datasetExistsStore(tenant, body.out));
         if (append) {
-          let existingRows: unknown[] = [];
-          try {
-            const parsed = JSON.parse(readFileSync(outAbs, "utf-8"));
-            if (Array.isArray(parsed)) existingRows = parsed;
-          } catch {
-            /* unreadable existing file — treat as fresh write */
-          }
+          const existingRows = (await readDatasetRowsStore(tenant, body.out)) ?? [];
           const merged = mergeDatasets(kind, existingRows, gen.valid, { allowedTasks });
           added = merged.added;
           duplicatesDropped += gen.valid.length - merged.added;
           valid = merged.valid;
           histogram = merged.histogram;
         }
-        mkdirSync(dirname(outAbs), { recursive: true });
-        writeFileSync(outAbs, JSON.stringify(valid, null, 2) + "\n", "utf-8");
+        await saveDatasetStore(tenant, body.out, valid);
         res.writeHead(201, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
@@ -1811,13 +1807,12 @@ const server = createServer(
           );
           return;
         }
-        if (!existsSync(abs)) {
+        const rawRows = await readDatasetRowsStore(ctx?.tenantId ?? "", rel);
+        if (rawRows === null) {
           res.writeHead(404, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: `dataset not found: ${rel}` }));
           return;
         }
-        const parsed = JSON.parse(readFileSync(abs, "utf-8"));
-        const rawRows = Array.isArray(parsed) ? parsed : [];
         // Allow the dataset's own (possibly custom) task labels; metric stays
         // strict (the scorer grades on it).
         const allowedTasks = rawRows
@@ -1921,7 +1916,7 @@ const server = createServer(
           1000,
         );
         const abs = resolvePath(repoRoot, rel);
-        // Contain reads to data/datasets and to .json files only.
+        // Contain reads to data/datasets and to .json files only (the logical key).
         if (
           !abs.startsWith(join(repoRoot, "data", "datasets")) ||
           !abs.endsWith(".json")
@@ -1932,13 +1927,12 @@ const server = createServer(
           );
           return;
         }
-        if (!existsSync(abs)) {
+        const all = await readDatasetRowsStore(ctx?.tenantId ?? "", rel);
+        if (all === null) {
           res.writeHead(404, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: `dataset not found: ${rel}` }));
           return;
         }
-        const parsed = JSON.parse(readFileSync(abs, "utf-8"));
-        const all = Array.isArray(parsed) ? parsed : [];
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({ path: rel, total: all.length, rows: all.slice(0, limit) }),
@@ -1973,13 +1967,12 @@ const server = createServer(
           );
           return;
         }
-        if (!existsSync(abs)) {
+        const all = await readDatasetRowsStore(ctx?.tenantId ?? "", rel);
+        if (all === null) {
           res.writeHead(404, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: `dataset not found: ${rel}` }));
           return;
         }
-        const parsed = JSON.parse(readFileSync(abs, "utf-8"));
-        const all = Array.isArray(parsed) ? parsed : [];
         const body = exportDataset(all, format);
         const base = basename(abs).replace(/\.json$/, "");
         res.writeHead(200, {
@@ -2461,19 +2454,17 @@ const server = createServer(
           return;
         }
 
-        // Preview/curate mode: return the rows for review instead of writing.
+        // Preview/curate mode: return the rows for review instead of persisting.
         const preview = body.preview === true;
-        // Top-up: merge into the existing file, deduping across both sets.
-        const append = body.append === true && !preview && existsSync(outAbs);
+        const tenant = ctx?.tenantId ?? "";
+        // Top-up: merge into the existing dataset, deduping across both sets.
+        const append =
+          body.append === true &&
+          !preview &&
+          (await datasetExistsStore(tenant, body.out));
         let addedCount = valid.length;
         if (append) {
-          let existingRows: unknown[] = [];
-          try {
-            const parsed = JSON.parse(readFileSync(outAbs, "utf-8"));
-            if (Array.isArray(parsed)) existingRows = parsed;
-          } catch {
-            /* unreadable existing file — treat as fresh write */
-          }
+          const existingRows = (await readDatasetRowsStore(tenant, body.out)) ?? [];
           const merged = mergeDatasets(kind, existingRows, valid, { allowedTasks });
           addedCount = merged.added;
           duplicatesDropped += valid.length - merged.added;
@@ -2481,8 +2472,7 @@ const server = createServer(
           histogram = merged.histogram;
         }
         if (!preview) {
-          mkdirSync(dirname(outAbs), { recursive: true });
-          writeFileSync(outAbs, JSON.stringify(valid, null, 2) + "\n", "utf-8");
+          await saveDatasetStore(tenant, body.out, valid);
         }
 
         const result = {

--- a/lib/dataset/dataset-store.ts
+++ b/lib/dataset/dataset-store.ts
@@ -1,0 +1,160 @@
+/**
+ * Dataset storage — Postgres when DATABASE_URL is set, filesystem otherwise.
+ *
+ * Generated datasets used to live only as JSON files under data/datasets, which
+ * is per-pod and ephemeral on a container platform (lost on every restart).
+ * When a database is configured, datasets are stored in the `datasets` table
+ * (tenant-scoped) so they persist and are shared across replicas. Without a DB,
+ * the original file behavior is preserved unchanged.
+ *
+ * The logical `path` (e.g. data/datasets/nemo-mcp/v1.json) is the key in both
+ * backends, so callers stay backend-agnostic.
+ */
+import { join, dirname } from "node:path";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { query, isDbConfigured } from "../db.js";
+import { listDatasets, summarizeRows, type DatasetSummary } from "./list.js";
+
+/** Repo root — this file is at <root>/lib/dataset, so up two levels. */
+function repoRoot(): string {
+  return join(import.meta.dirname, "..", "..");
+}
+
+function absFor(path: string): string {
+  return join(repoRoot(), path);
+}
+
+/** True when datasets are stored in Postgres (vs. the filesystem). */
+export function datasetDbEnabled(): boolean {
+  return isDbConfigured();
+}
+
+interface DatasetRowRecord {
+  path: string;
+  name: string;
+  family: string;
+  kind: "security" | "quality";
+  row_count: number;
+  histogram: Record<string, number>;
+  size_bytes: number;
+}
+
+/** List a tenant's datasets (DB) or all dataset files (file mode). */
+export async function listDatasetsStore(
+  tenantId: string,
+): Promise<DatasetSummary[]> {
+  if (!isDbConfigured()) return listDatasets(repoRoot());
+  const res = await query<DatasetRowRecord>(
+    `SELECT path, name, family, kind, row_count, histogram, size_bytes
+       FROM datasets WHERE tenant_id = $1 ORDER BY path`,
+    [tenantId],
+  );
+  return res.rows.map((r) => ({
+    path: r.path,
+    name: r.name,
+    family: r.family,
+    kind: r.kind,
+    rowCount: r.row_count,
+    histogram: r.histogram ?? {},
+    sizeBytes: r.size_bytes,
+  }));
+}
+
+/** Read one dataset's rows, or null if it doesn't exist. */
+export async function readDatasetRowsStore(
+  tenantId: string,
+  path: string,
+): Promise<unknown[] | null> {
+  if (!isDbConfigured()) {
+    const abs = absFor(path);
+    if (!existsSync(abs)) return null;
+    const parsed = JSON.parse(readFileSync(abs, "utf-8"));
+    return Array.isArray(parsed) ? parsed : [];
+  }
+  const res = await query<{ rows: unknown }>(
+    `SELECT rows FROM datasets WHERE tenant_id = $1 AND path = $2`,
+    [tenantId, path],
+  );
+  if (res.rows.length === 0) return null;
+  const rows = res.rows[0].rows;
+  return Array.isArray(rows) ? rows : [];
+}
+
+/** Whether a dataset exists (used to decide append vs. fresh write). */
+export async function datasetExistsStore(
+  tenantId: string,
+  path: string,
+): Promise<boolean> {
+  if (!isDbConfigured()) return existsSync(absFor(path));
+  const res = await query<{ one: number }>(
+    `SELECT 1 AS one FROM datasets WHERE tenant_id = $1 AND path = $2`,
+    [tenantId, path],
+  );
+  return res.rows.length > 0;
+}
+
+/**
+ * Upsert a dataset (full replace of its rows). Returns the computed summary.
+ * In file mode this writes the JSON file exactly as before.
+ */
+export async function saveDatasetStore(
+  tenantId: string,
+  path: string,
+  rows: unknown[],
+): Promise<DatasetSummary> {
+  const summary = summarizeRows(path, rows);
+  if (!isDbConfigured()) {
+    const abs = absFor(path);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, JSON.stringify(rows, null, 2) + "\n", "utf-8");
+    return summary;
+  }
+  await query(
+    `INSERT INTO datasets
+       (tenant_id, path, name, family, kind, row_count, histogram, rows, size_bytes, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+     ON CONFLICT (tenant_id, path) DO UPDATE SET
+       name       = EXCLUDED.name,
+       family     = EXCLUDED.family,
+       kind       = EXCLUDED.kind,
+       row_count  = EXCLUDED.row_count,
+       histogram  = EXCLUDED.histogram,
+       rows       = EXCLUDED.rows,
+       size_bytes = EXCLUDED.size_bytes,
+       updated_at = now()`,
+    [
+      tenantId,
+      path,
+      summary.name,
+      summary.family,
+      summary.kind,
+      summary.rowCount,
+      JSON.stringify(summary.histogram),
+      JSON.stringify(rows),
+      summary.sizeBytes,
+    ],
+  );
+  return summary;
+}
+
+/** Delete a dataset from whichever backend holds it. */
+export async function deleteDatasetStore(
+  tenantId: string,
+  path: string,
+): Promise<void> {
+  if (!isDbConfigured()) {
+    const abs = absFor(path);
+    if (existsSync(abs)) rmSync(abs);
+    return;
+  }
+  await query(`DELETE FROM datasets WHERE tenant_id = $1 AND path = $2`, [
+    tenantId,
+    path,
+  ]);
+}

--- a/lib/dataset/list.ts
+++ b/lib/dataset/list.ts
@@ -29,15 +29,16 @@ function inferFamily(relPath: string): string {
   return "unknown";
 }
 
-function summarizeFile(root: string, absPath: string): DatasetSummary | null {
-  let rows: unknown;
-  try {
-    rows = JSON.parse(readFileSync(absPath, "utf-8"));
-  } catch {
-    return null;
-  }
-  if (!Array.isArray(rows)) return null;
-
+/**
+ * Compute a dataset summary from a logical path + its rows. Pure — used by both
+ * the filesystem lister and the DB-backed store so a dataset looks identical
+ * whichever backend holds it. `sizeBytes` defaults to the JSON byte length.
+ */
+export function summarizeRows(
+  relPath: string,
+  rows: unknown[],
+  sizeBytes?: number,
+): DatasetSummary {
   // Quality rows carry `task` + `input`; security rows carry `category` + `prompt`.
   const first = rows.find((r) => r && typeof r === "object") as
     | Record<string, unknown>
@@ -53,16 +54,27 @@ function summarizeFile(root: string, absPath: string): DatasetSummary | null {
       histogram[bucket] = (histogram[bucket] ?? 0) + 1;
     }
   }
-  const relPath = relative(root, absPath);
   return {
     path: relPath,
-    name: absPath.split("/").pop()!.replace(/\.json$/i, ""),
+    name: relPath.split("/").pop()!.replace(/\.json$/i, ""),
     family: inferFamily(relPath),
     kind,
     rowCount: rows.length,
     histogram,
-    sizeBytes: statSync(absPath).size,
+    sizeBytes:
+      sizeBytes ?? Buffer.byteLength(JSON.stringify(rows), "utf-8"),
   };
+}
+
+function summarizeFile(root: string, absPath: string): DatasetSummary | null {
+  let rows: unknown;
+  try {
+    rows = JSON.parse(readFileSync(absPath, "utf-8"));
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(rows)) return null;
+  return summarizeRows(relative(root, absPath), rows, statSync(absPath).size);
 }
 
 /**

--- a/lib/migrations/003-datasets.sql
+++ b/lib/migrations/003-datasets.sql
@@ -1,0 +1,26 @@
+-- Migration 003: Generated eval datasets persistence
+-- Stores generated security/quality datasets in the database so they survive
+-- pod restarts/redeploys and are shared across replicas (the container
+-- filesystem is per-pod and ephemeral). Rows are stored as plaintext JSONB —
+-- datasets are synthetic evaluation prompts, not user data, and keeping them
+-- queryable is worth more than the encryption reports/guardrails use.
+
+CREATE TABLE IF NOT EXISTS datasets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   UUID NOT NULL REFERENCES tenants(id),
+  -- Logical key, e.g. data/datasets/nemo-mcp/v1.json — the same relative path
+  -- the file backend uses, so callers are backend-agnostic.
+  path        TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  family      TEXT NOT NULL,
+  kind        TEXT NOT NULL,            -- 'security' | 'quality'
+  row_count   INTEGER NOT NULL DEFAULT 0,
+  histogram   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  rows        JSONB NOT NULL DEFAULT '[]'::jsonb,
+  size_bytes  INTEGER NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_datasets_tenant ON datasets(tenant_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_datasets_tenant_path ON datasets(tenant_id, path);

--- a/openshift/deploy-no-db.example.yaml
+++ b/openshift/deploy-no-db.example.yaml
@@ -17,7 +17,21 @@ stringData:
   SIMPLE_AUTH_SESSION_SECRET: "replace-this"
   SIMPLE_AUTH_PASSWORD: "changeme"
 ---
-# Red Team Dashboard (no Postgres, emptyDir volumes)
+# PVC: Generated eval datasets (must persist across restarts, unlike the
+# emptyDir report volumes below).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: red-team-datasets
+  labels:
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 5Gi
+---
+# Red Team Dashboard (no Postgres, emptyDir volumes for reports)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -85,6 +99,8 @@ spec:
               mountPath: /app/report
             - name: guardrail-reports
               mountPath: /app/reports
+            - name: datasets
+              mountPath: /app/data/datasets
           livenessProbe:
             httpGet:
               path: /
@@ -111,6 +127,9 @@ spec:
         - name: guardrail-reports
           emptyDir:
             sizeLimit: 100G
+        - name: datasets
+          persistentVolumeClaim:
+            claimName: red-team-datasets
 ---
 apiVersion: v1
 kind: Service

--- a/openshift/deploy-with-db.example.yaml
+++ b/openshift/deploy-with-db.example.yaml
@@ -75,6 +75,20 @@ spec:
       storage: 2Gi
 
 ---
+# PVC: Generated eval datasets (persisted across restarts).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: red-team-datasets
+  labels:
+    app.kubernetes.io/part-of: red-team-ai
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 5Gi
+
+---
 # ── Postgres Deployment ──
 apiVersion: apps/v1
 kind: Deployment
@@ -235,6 +249,8 @@ spec:
               mountPath: /app/report
             - name: guardrail-reports
               mountPath: /app/reports
+            - name: datasets
+              mountPath: /app/data/datasets
           livenessProbe:
             httpGet:
               path: /
@@ -261,6 +277,9 @@ spec:
         - name: guardrail-reports
           persistentVolumeClaim:
             claimName: red-team-guardrail-reports
+        - name: datasets
+          persistentVolumeClaim:
+            claimName: red-team-datasets
 
 ---
 # Dashboard Service

--- a/tests/dataset-store.test.ts
+++ b/tests/dataset-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { summarizeRows } from "../lib/dataset/list.js";
+import {
+  saveDatasetStore,
+  readDatasetRowsStore,
+  listDatasetsStore,
+  datasetExistsStore,
+  deleteDatasetStore,
+  datasetDbEnabled,
+} from "../lib/dataset/dataset-store.js";
+
+describe("summarizeRows", () => {
+  it("infers security kind + category histogram", () => {
+    const s = summarizeRows("data/datasets/nemo-mcp/v1.json", [
+      { category: "tool_misuse", prompt: "x" },
+      { category: "tool_misuse", prompt: "y" },
+      { category: "rbac_bypass", prompt: "z" },
+    ]);
+    expect(s.kind).toBe("security");
+    expect(s.family).toBe("mcp");
+    expect(s.name).toBe("v1");
+    expect(s.rowCount).toBe(3);
+    expect(s.histogram).toEqual({ tool_misuse: 2, rbac_bypass: 1 });
+    expect(s.sizeBytes).toBeGreaterThan(0);
+  });
+
+  it("infers quality kind + task histogram", () => {
+    const s = summarizeRows("data/datasets/quality-agent/v1.json", [
+      { task: "tool_selection", input: "a" },
+      { task: "rag_answer", input: "b" },
+    ]);
+    expect(s.kind).toBe("quality");
+    expect(s.family).toBe("agent");
+    expect(s.histogram).toEqual({ tool_selection: 1, rag_answer: 1 });
+  });
+});
+
+// File-mode store (no DATABASE_URL). Skipped automatically if a DB is set so we
+// never touch a real database from unit tests. Writes under a temp dataset dir
+// and cleans it up.
+describe.skipIf(datasetDbEnabled())("dataset-store (file mode)", () => {
+  const TENANT = "unused-in-file-mode";
+  const PATH = "data/datasets/__store_test__/roundtrip.json";
+  const repoRoot = join(import.meta.dirname, "..");
+
+  afterEach(() => {
+    const dir = join(repoRoot, "data", "datasets", "__store_test__");
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("save → exists → read → list → delete round-trips on disk", async () => {
+    const rows = [
+      { category: "tool_misuse", name: "c1", prompt: "p1", severity: "high", successCriteria: "sc" },
+      { category: "rbac_bypass", name: "c2", prompt: "p2", severity: "low", successCriteria: "sc" },
+    ];
+    const summary = await saveDatasetStore(TENANT, PATH, rows);
+    expect(summary.rowCount).toBe(2);
+
+    expect(await datasetExistsStore(TENANT, PATH)).toBe(true);
+    const back = await readDatasetRowsStore(TENANT, PATH);
+    expect(back).toHaveLength(2);
+    expect((back![0] as { prompt: string }).prompt).toBe("p1");
+
+    const all = await listDatasetsStore(TENANT);
+    expect(all.some((d) => d.path === PATH && d.rowCount === 2)).toBe(true);
+
+    await deleteDatasetStore(TENANT, PATH);
+    expect(await datasetExistsStore(TENANT, PATH)).toBe(false);
+    expect(await readDatasetRowsStore(TENANT, PATH)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem
Generated datasets were written to `data/datasets/**` inside the pod, but nothing mounted a volume there — so on every restart/redeploy the Datasets tab reset to empty ("Datasets (0)"). Everything lived on the pod's ephemeral layer.

## Fix — two complementary persistence paths
1. **Postgres table (`ec6abc2`)** — when `DATABASE_URL` is set, datasets are stored in a new tenant-scoped `datasets` table instead of files. Survives restarts *and* is shared across replicas.
   - `lib/migrations/003-datasets.sql` — `datasets` table (rows as JSONB, `UNIQUE(tenant_id, path)`), auto-applied on startup.
   - `lib/dataset/dataset-store.ts` — DB-or-file store (`save`/`list`/`read`/`exists`/`delete`); DB when `isDbConfigured()`, else the original filesystem writes (no change for file-mode deploys).
   - `list.ts` — extracted a pure `summarizeRows()` reused by both backends.
   - `server.ts` — all dataset endpoints (list, rows, save, generate-write, export, promote, eval-quality read) go through the store with the request's tenantId. Path containment/validation unchanged; path is now a logical key.
2. **PVC fallback (`726ccb7`)** — for file-mode (no-db) deploys, a `red-team-datasets` PVC mounted at `/app/data/datasets` in the OpenShift manifests.

## Verification
- Live Postgres E2E: generated a dataset (stored in the table, no file) → **restarted the server** → dataset persisted (list + readback intact).
- 564 tests pass (added `summarizeRows` + store round-trip tests).
- Scan/scoring execution engine byte-identical to `main` (generation/persistence only).

## Deploy note
- With a DB (`deploy-with-db`, `DATABASE_URL` set) → datasets persist in Postgres automatically.
- Without a DB (`deploy-no-db`) → apply the PVC (`oc apply -f openshift/deploy-no-db.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)