### PR TITLE
fix(datasets): don't require a target URL when reusing a previous scan

### DIFF
--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -638,7 +638,11 @@ export default function NewScanPage() {
     setError(null);
     setSuccess(null);
 
-    if (!targetReady) {
+    // When reusing a previous scan's target (quality eval), the form's target
+    // fields are ignored — its config comes from the saved run — so skip the
+    // "target base URL required" guard.
+    const usingPreviousTarget = mode === "quality" && targetSource === "previous";
+    if (!usingPreviousTarget && !targetReady) {
       setError(
         targetType === "mcp"
           ? mcpTransport === "streamable_http"


### PR DESCRIPTION
The quality-eval "Reuse a previous scan" mode still hit the form's early "Target base URL is required" guard, because that guard ran before the quality branch — so selecting a previous scan errored instead of running.

Skip the target-URL guard when mode is quality and the target source is a previous scan (its config comes from the saved run, not the form). Security scans and the "configure new target" quality path are unchanged — they still require a target.

The reused target can be any type the scanner supports (HTTP/MCP/WebSocket): the quality scorer sends via the same executeAttack/target-adapter the red-team runner uses, so it's target-type-agnostic.