### PR TITLE
feat(evals): persist quality-eval reports + show them in the Evaluati…

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -83,6 +83,11 @@ import {
 import { estimateCost } from "../lib/dataset/cost-estimate.js";
 import { runQualityEval } from "../lib/quality/scorer.js";
 import {
+  storeQualityReport,
+  listQualityReports,
+  getQualityReport,
+} from "../lib/quality-report-store.js";
+import {
   listDatasetsStore,
   readDatasetRowsStore,
   datasetExistsStore,
@@ -1896,6 +1901,17 @@ const server = createServer(
             );
           },
         });
+        // Persist the report so it shows up in the Evaluations tab and survives
+        // restarts. Best-effort: a storage hiccup must not fail the eval itself.
+        let savedFilename: string | undefined;
+        try {
+          const saved = await storeQualityReport(report, ctx?.tenantId ?? "");
+          savedFilename = saved.filename;
+        } catch (e) {
+          console.warn(
+            `  [eval] failed to persist quality report: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
         if (ctx) {
           await logAudit(ctx, "eval.quality", "dataset", rel, {
             targetUrl: describeTarget(config),
@@ -1904,7 +1920,9 @@ const server = createServer(
             passed: report.summary.passed,
           });
         }
-        res.write(JSON.stringify({ type: "done", report }) + "\n");
+        res.write(
+          JSON.stringify({ type: "done", report, filename: savedFilename }) + "\n",
+        );
         res.end();
       } catch (err) {
         if (streamStarted) {
@@ -1920,6 +1938,49 @@ const server = createServer(
           res.writeHead(500, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: formatErrorDetails(err) }));
         }
+      }
+      return;
+    }
+
+    // API: list persisted quality-eval reports (Evaluations tab).
+    if (url.pathname === "/api/quality-reports" && req.method === "GET") {
+      try {
+        const reports = await listQualityReports(ctx?.tenantId ?? "");
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ reports }));
+      } catch (err) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: formatErrorDetails(err) }));
+      }
+      return;
+    }
+
+    // API: fetch one full quality-eval report (per-row detail).
+    if (
+      url.pathname.startsWith("/api/quality-report/") &&
+      req.method === "GET"
+    ) {
+      try {
+        const filename = decodeURIComponent(
+          url.pathname.slice("/api/quality-report/".length),
+        );
+        // Contain to a plain filename (no path traversal).
+        if (!filename || filename.includes("/") || !filename.endsWith(".json")) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "invalid report filename" }));
+          return;
+        }
+        const report = await getQualityReport(filename, ctx?.tenantId ?? "");
+        if (!report) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "report not found" }));
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ report }));
+      } catch (err) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: formatErrorDetails(err) }));
       }
       return;
     }

--- a/dashboard/ui/src/api/datasets.ts
+++ b/dashboard/ui/src/api/datasets.ts
@@ -362,6 +362,31 @@ export async function evalQualityStream(
   if (tail) onEvent(JSON.parse(tail) as EvalQualityStreamEvent);
 }
 
+// --- persisted quality-eval reports (Evaluations tab) ---
+
+export interface QualityReportMeta {
+  id: string;
+  filename: string;
+  timestamp: string;
+  dataset: string;
+  targetUrl: string;
+  score: number; // 0..100
+  passed: number;
+  total: number;
+  errors: number;
+  threshold: number;
+}
+
+export function listQualityReports() {
+  return apiFetch<{ reports: QualityReportMeta[] }>("/api/quality-reports");
+}
+
+export function getQualityReport(filename: string) {
+  return apiFetch<{ report: QualityEvalReport }>(
+    `/api/quality-report/${encodeURIComponent(filename)}`,
+  );
+}
+
 export interface EvalRunPoint {
   filename: string;
   timestamp: string;

--- a/dashboard/ui/src/pages/EvaluationsPage/index.tsx
+++ b/dashboard/ui/src/pages/EvaluationsPage/index.tsx
@@ -1,6 +1,13 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
-import { listDatasets, type DatasetSummary } from "@/api/datasets";
+import {
+  listDatasets,
+  listQualityReports,
+  getQualityReport,
+  type DatasetSummary,
+  type QualityReportMeta,
+  type QualityEvalReport,
+} from "@/api/datasets";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,6 +24,11 @@ import {
   ListChecks,
   ArrowRight,
   Database,
+  Loader2,
+  ChevronRight,
+  ChevronDown,
+  TrendingUp,
+  TrendingDown,
 } from "lucide-react";
 
 type Status = "live" | "cli" | "planned";
@@ -190,6 +202,173 @@ function EvalCard({ e, hue }: { e: EvalType; hue: string }) {
 const SEC = "var(--eval-sec, #e05365)";
 const QUAL = "var(--eval-qual, #12a594)";
 
+/** Score change vs the previous run of the SAME dataset (regression signal). */
+function scoreDelta(reports: QualityReportMeta[], idx: number): number | null {
+  const r = reports[idx];
+  for (let j = idx + 1; j < reports.length; j++) {
+    if (reports[j].dataset === r.dataset) return r.score - reports[j].score;
+  }
+  return null;
+}
+
+function shortName(path: string): string {
+  return path.split("/").slice(-2).join("/").replace(/\.json$/i, "") || path;
+}
+
+function QualityRunRow({
+  meta,
+  delta,
+}: {
+  meta: QualityReportMeta;
+  delta: number | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const [report, setReport] = useState<QualityEvalReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const toggle = async () => {
+    const next = !open;
+    setOpen(next);
+    if (next && !report) {
+      setLoading(true);
+      try {
+        const r = await getQualityReport(meta.filename);
+        setReport(r.report);
+      } catch {
+        /* ignore */
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+  return (
+    <div className="rounded-lg border border-border">
+      <button
+        type="button"
+        onClick={toggle}
+        className="w-full flex items-center gap-3 p-3 text-left"
+      >
+        {open ? (
+          <ChevronDown className="w-4 h-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="w-4 h-4 shrink-0 text-muted-foreground" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium">{shortName(meta.dataset)}</span>
+            <Badge variant="outline" className="text-[10px]">
+              {meta.targetUrl || "unknown target"}
+            </Badge>
+          </div>
+          <span className="text-[11px] text-muted-foreground">
+            {new Date(meta.timestamp).toLocaleString()}
+          </span>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          {delta !== null && delta !== 0 && (
+            <span
+              className={`flex items-center gap-0.5 text-[11px] ${delta > 0 ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}`}
+            >
+              {delta > 0 ? (
+                <TrendingUp className="w-3 h-3" />
+              ) : (
+                <TrendingDown className="w-3 h-3" />
+              )}
+              {delta > 0 ? "+" : ""}
+              {delta}
+            </span>
+          )}
+          <span className="text-sm font-semibold tabular-nums">{meta.score}%</span>
+          <span className="text-[11px] text-muted-foreground tabular-nums">
+            {meta.passed}/{meta.total}
+            {meta.errors > 0 && (
+              <span className="text-destructive"> · {meta.errors} err</span>
+            )}
+          </span>
+        </div>
+      </button>
+      {open && (
+        <div className="border-t border-border p-3 space-y-2">
+          {loading && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" /> Loading…
+            </div>
+          )}
+          {report && (
+            <>
+              <div className="flex flex-wrap gap-1.5">
+                {Object.entries(report.summary.byMetric).map(([m, v]) => (
+                  <span
+                    key={m}
+                    className="text-[11px] rounded border border-border px-1.5 py-0.5"
+                  >
+                    {m}: {(v.mean * 100).toFixed(0)}% ({v.passed}/{v.count})
+                  </span>
+                ))}
+              </div>
+              <div className="max-h-64 overflow-y-auto space-y-1">
+                {(report.results as { metric: string; score: number; pass: boolean; error?: string }[])
+                  .slice(0, 50)
+                  .map((r, i) => (
+                    <div key={i} className="flex items-center gap-2 text-xs">
+                      <span
+                        className={
+                          r.error
+                            ? "text-amber-600 dark:text-amber-400"
+                            : r.pass
+                              ? "text-emerald-600 dark:text-emerald-400"
+                              : "text-destructive"
+                        }
+                      >
+                        {r.error ? "ERR" : r.pass ? "PASS" : "FAIL"}
+                      </span>
+                      <span className="text-muted-foreground">{r.metric}</span>
+                      <span className="tabular-nums">{r.score.toFixed(2)}</span>
+                    </div>
+                  ))}
+                {report.results.length > 50 && (
+                  <p className="text-[11px] text-muted-foreground">
+                    Showing first 50 of {report.results.length} rows.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function QualityRunsSection() {
+  const [reports, setReports] = useState<QualityReportMeta[]>([]);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    listQualityReports()
+      .then((r) => setReports(r.reports))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+  if (loading || reports.length === 0) return null;
+  return (
+    <section className="space-y-3">
+      <div className="flex items-baseline gap-2">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-foreground">
+          Recent quality evals
+        </h2>
+        <span className="text-[11px] text-muted-foreground">
+          {reports.length} run{reports.length === 1 ? "" : "s"} · newest first ·
+          ▲/▼ vs the previous run of the same dataset
+        </span>
+      </div>
+      <div className="space-y-2">
+        {reports.map((r, i) => (
+          <QualityRunRow key={r.id} meta={r} delta={scoreDelta(reports, i)} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function EvaluationsPage() {
   const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
   useEffect(() => {
@@ -215,6 +394,9 @@ export function EvaluationsPage() {
           </p>
         </div>
       </div>
+
+      {/* Live: persisted quality-eval runs (score-over-time) */}
+      <QualityRunsSection />
 
       {/* Two axes */}
       <div className="grid gap-4 md:grid-cols-2">

--- a/lib/migrations/004-quality-reports.sql
+++ b/lib/migrations/004-quality-reports.sql
@@ -1,0 +1,28 @@
+-- Migration 004: Functional-quality evaluation reports persistence
+-- Persists quality-eval runs (dataset scored against a target) so they survive
+-- restarts and show up in the Evaluations tab with score-over-time. The full
+-- report is encrypted per-tenant (it contains the target's responses); the
+-- summary columns are plaintext for listing/trends without decryption.
+
+CREATE TABLE IF NOT EXISTS quality_reports (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   UUID NOT NULL REFERENCES tenants(id),
+  filename    TEXT NOT NULL,
+  report_enc  BYTEA NOT NULL,
+  iv          BYTEA NOT NULL,
+  auth_tag    BYTEA NOT NULL,
+  dataset     TEXT,
+  target_url  TEXT,
+  score       INTEGER NOT NULL DEFAULT 0,   -- mean score, 0..100
+  passed      INTEGER NOT NULL DEFAULT 0,
+  total       INTEGER NOT NULL DEFAULT 0,
+  errors      INTEGER NOT NULL DEFAULT 0,
+  threshold   DOUBLE PRECISION,
+  report_ts   TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_quality_reports_tenant ON quality_reports(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_quality_reports_tenant_ts ON quality_reports(tenant_id, report_ts DESC);
+CREATE INDEX IF NOT EXISTS idx_quality_reports_dataset ON quality_reports(tenant_id, dataset, report_ts);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_quality_reports_filename ON quality_reports(tenant_id, filename);

--- a/lib/quality-report-store.ts
+++ b/lib/quality-report-store.ts
@@ -1,0 +1,195 @@
+/**
+ * Quality-eval report storage — Postgres (encrypted) when DATABASE_URL is set,
+ * a JSON file under report/quality otherwise. Mirrors the guardrail/report
+ * stores. The full report is encrypted per-tenant in the DB (it contains the
+ * target's responses); plaintext summary columns support listing + trends.
+ */
+import { join } from "node:path";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+} from "node:fs";
+import { query, isDbConfigured } from "./db.js";
+import { encryptWithTenantKey, decryptWithTenantKey } from "./encryption.js";
+import type { QualityReport } from "./quality/types.js";
+
+function reportDir(): string {
+  return join(import.meta.dirname, "..", "report", "quality");
+}
+
+export interface QualityReportMeta {
+  id: string;
+  filename: string;
+  timestamp: string;
+  dataset: string;
+  targetUrl: string;
+  score: number; // 0..100
+  passed: number;
+  total: number;
+  errors: number;
+  threshold: number;
+}
+
+function summaryOf(report: QualityReport) {
+  return {
+    dataset: report.dataset ?? "",
+    targetUrl: report.targetUrl ?? "",
+    score: report.summary.score,
+    passed: report.summary.passed,
+    total: report.summary.total,
+    errors: report.summary.errors,
+    threshold: report.passThreshold,
+    timestamp: report.timestamp,
+  };
+}
+
+function filenameFor(report: QualityReport): string {
+  return `quality-${report.timestamp.replace(/[:.]/g, "-")}.json`;
+}
+
+/** Persist a quality report. Returns its filename (the stable id in file mode). */
+export async function storeQualityReport(
+  report: QualityReport,
+  tenantId: string,
+): Promise<{ filename: string }> {
+  const filename = filenameFor(report);
+
+  if (!isDbConfigured()) {
+    const dir = reportDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, filename), JSON.stringify(report, null, 2) + "\n", "utf-8");
+    return { filename };
+  }
+
+  const tenantResult = await query<{ encryption_key_enc: string }>(
+    "SELECT encryption_key_enc FROM tenants WHERE id = $1",
+    [tenantId],
+  );
+  if (tenantResult.rows.length === 0) {
+    throw new Error(`Tenant not found: ${tenantId}`);
+  }
+  const tenantKeyEnc = tenantResult.rows[0].encryption_key_enc;
+  const { ciphertext, iv, authTag } = encryptWithTenantKey(
+    JSON.stringify(report),
+    tenantKeyEnc,
+  );
+  const s = summaryOf(report);
+  await query(
+    `INSERT INTO quality_reports (
+       tenant_id, filename, report_enc, iv, auth_tag,
+       dataset, target_url, score, passed, total, errors, threshold, report_ts
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+     ON CONFLICT (tenant_id, filename) DO UPDATE SET
+       report_enc = EXCLUDED.report_enc, iv = EXCLUDED.iv, auth_tag = EXCLUDED.auth_tag,
+       dataset = EXCLUDED.dataset, target_url = EXCLUDED.target_url,
+       score = EXCLUDED.score, passed = EXCLUDED.passed, total = EXCLUDED.total,
+       errors = EXCLUDED.errors, threshold = EXCLUDED.threshold, report_ts = EXCLUDED.report_ts`,
+    [
+      tenantId,
+      filename,
+      ciphertext,
+      iv,
+      authTag,
+      s.dataset,
+      s.targetUrl,
+      s.score,
+      s.passed,
+      s.total,
+      s.errors,
+      s.threshold,
+      s.timestamp,
+    ],
+  );
+  return { filename };
+}
+
+/** List quality reports for a tenant (summary only), newest first. */
+export async function listQualityReports(
+  tenantId: string,
+): Promise<QualityReportMeta[]> {
+  if (!isDbConfigured()) {
+    const dir = reportDir();
+    if (!existsSync(dir)) return [];
+    const metas: QualityReportMeta[] = [];
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".json")) continue;
+      try {
+        const report = JSON.parse(
+          readFileSync(join(dir, f), "utf-8"),
+        ) as QualityReport;
+        const s = summaryOf(report);
+        metas.push({ id: f, filename: f, ...s });
+      } catch {
+        /* skip unreadable */
+      }
+    }
+    return metas.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  }
+
+  const res = await query<{
+    id: string;
+    filename: string;
+    report_ts: string;
+    dataset: string;
+    target_url: string;
+    score: number;
+    passed: number;
+    total: number;
+    errors: number;
+    threshold: number;
+  }>(
+    `SELECT id, filename, report_ts, dataset, target_url,
+            score, passed, total, errors, threshold
+       FROM quality_reports WHERE tenant_id = $1 ORDER BY report_ts DESC`,
+    [tenantId],
+  );
+  return res.rows.map((r) => ({
+    id: r.id,
+    filename: r.filename,
+    timestamp: r.report_ts,
+    dataset: r.dataset ?? "",
+    targetUrl: r.target_url ?? "",
+    score: r.score,
+    passed: r.passed,
+    total: r.total,
+    errors: r.errors,
+    threshold: r.threshold,
+  }));
+}
+
+/** Fetch one full quality report (decrypted) by filename, or null. */
+export async function getQualityReport(
+  filename: string,
+  tenantId: string,
+): Promise<QualityReport | null> {
+  if (!isDbConfigured()) {
+    const abs = join(reportDir(), filename);
+    if (!existsSync(abs)) return null;
+    try {
+      return JSON.parse(readFileSync(abs, "utf-8")) as QualityReport;
+    } catch {
+      return null;
+    }
+  }
+  const res = await query<{ report_enc: Buffer; iv: Buffer; auth_tag: Buffer }>(
+    `SELECT report_enc, iv, auth_tag FROM quality_reports
+      WHERE tenant_id = $1 AND filename = $2`,
+    [tenantId, filename],
+  );
+  if (res.rows.length === 0) return null;
+  const tenantResult = await query<{ encryption_key_enc: string }>(
+    "SELECT encryption_key_enc FROM tenants WHERE id = $1",
+    [tenantId],
+  );
+  if (tenantResult.rows.length === 0) return null;
+  const json = decryptWithTenantKey(
+    res.rows[0].report_enc,
+    res.rows[0].iv,
+    res.rows[0].auth_tag,
+    tenantResult.rows[0].encryption_key_enc,
+  );
+  return JSON.parse(json) as QualityReport;
+}

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -147,6 +147,16 @@ const PERMISSIONS: RoutePermission[] = [
     roles: ["admin"],
   },
   { method: "GET", pattern: /^\/api\/eval-runs$/, roles: ["admin", "viewer"] },
+  {
+    method: "GET",
+    pattern: /^\/api\/quality-reports$/,
+    roles: ["admin", "viewer"],
+  },
+  {
+    method: "GET",
+    pattern: /^\/api\/quality-report\//,
+    roles: ["admin", "viewer"],
+  },
 
   // Audit log
   { method: "GET", pattern: /^\/api\/audit-log/, roles: ["admin", "auditor"] },

--- a/tests/quality-report-store.test.ts
+++ b/tests/quality-report-store.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  storeQualityReport,
+  listQualityReports,
+  getQualityReport,
+} from "../lib/quality-report-store.js";
+import { isDbConfigured } from "../lib/db.js";
+import type { QualityReport } from "../lib/quality/types.js";
+
+function makeReport(ts: string, dataset: string, score: number): QualityReport {
+  return {
+    timestamp: ts,
+    targetUrl: "http://localhost:9/agent",
+    dataset,
+    passThreshold: 0.7,
+    summary: {
+      total: 2,
+      scored: 2,
+      errors: 0,
+      score,
+      passed: score >= 50 ? 2 : 1,
+      byMetric: { exact_match: { count: 2, mean: score / 100, passed: 2 } },
+      byTask: { rag_answer: { count: 2, mean: score / 100, passed: 2 } },
+    },
+    results: [
+      {
+        row: { task: "rag_answer", name: "e1", input: "hi", metric: "exact_match" },
+        score: 1,
+        pass: true,
+        metric: "exact_match",
+        scorer: "deterministic",
+        response: "hi",
+        statusCode: 200,
+        responseTimeMs: 1,
+      },
+    ],
+  } as unknown as QualityReport;
+}
+
+// File-mode store (skipped if a DB is configured — never touch a real DB here).
+describe.skipIf(isDbConfigured())("quality-report-store (file mode)", () => {
+  const TENANT = "unused-in-file-mode";
+  const dir = join(import.meta.dirname, "..", "report", "quality");
+
+  afterEach(() => {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("store → list → get round-trips on disk, newest first", async () => {
+    const { filename: f1 } = await storeQualityReport(
+      makeReport("2026-07-01T10:00:00.000Z", "data/datasets/quality-agent/v1.json", 80),
+      TENANT,
+    );
+    await storeQualityReport(
+      makeReport("2026-07-02T10:00:00.000Z", "data/datasets/quality-agent/v1.json", 90),
+      TENANT,
+    );
+
+    const list = await listQualityReports(TENANT);
+    expect(list).toHaveLength(2);
+    // newest first
+    expect(list[0].timestamp).toBe("2026-07-02T10:00:00.000Z");
+    expect(list[0].score).toBe(90);
+    expect(list[0].dataset).toContain("v1.json");
+
+    const full = await getQualityReport(f1, TENANT);
+    expect(full).not.toBeNull();
+    expect(full!.summary.score).toBe(80);
+    expect(full!.results).toHaveLength(1);
+  });
+
+  it("getQualityReport returns null for a missing file", async () => {
+    expect(await getQualityReport("quality-nope.json", TENANT)).toBeNull();
+  });
+});

--- a/tests/rbac-datasets.test.ts
+++ b/tests/rbac-datasets.test.ts
@@ -47,6 +47,14 @@ describe("RBAC for dataset/eval endpoints (regression: login-loop 403)", () => {
     expect(checkPermission("POST", "/api/datasets/eval-quality", "viewer")).toBe(false);
     expect(checkPermission("POST", "/api/datasets/eval-quality", "auditor")).toBe(false);
   });
+  it("allows viewer+admin to read persisted quality reports", () => {
+    expect(checkPermission("GET", "/api/quality-reports", "viewer")).toBe(true);
+    expect(checkPermission("GET", "/api/quality-reports", "admin")).toBe(true);
+    expect(checkPermission("GET", "/api/quality-report/quality-x.json", "viewer")).toBe(true);
+    expect(checkPermission("GET", "/api/quality-report/quality-x.json", "admin")).toBe(true);
+    // auditor is not a dataset/eval reader
+    expect(checkPermission("GET", "/api/quality-reports", "auditor")).toBe(false);
+  });
   it("GET /api/datasets pattern does not swallow the generate path", () => {
     // ensure the two rules stay distinct
     expect(checkPermission("GET", "/api/datasets/generate", "viewer")).toBe(false);


### PR DESCRIPTION
…ons tab

Quality evals run from the UI were ephemeral — streamed to the page and lost on reload, never in any tab. Now each run is persisted like a scan report and surfaced with score-over-time.

- migration 004-quality-reports.sql: `quality_reports` table (tenant-scoped), full report encrypted per-tenant, plaintext summary columns for listing/trends.
- lib/quality-report-store.ts: store/list/get — Postgres (encrypted) when a DB is configured, else a JSON file under report/quality (mirrors the report and guardrail stores).
- server: /api/datasets/eval-quality persists the report on completion (best-effort; a storage hiccup never fails the eval) and returns its filename. New GET /api/quality-reports (list) + GET /api/quality-report/:file (detail), viewer+admin.
- Evaluations tab: a live "Recent quality evals" list — dataset, target, score, passed/total, ▲/▼ delta vs the previous run of the same dataset (regression signal); expand a run for per-metric + per-row PASS/FAIL.

Verified end-to-end against Postgres: ran an eval → report stored in the table → listed + detail decrypted → survived a server restart. 567 tests pass; scan engine untouched.