### PR TITLE
feat(datasets): rename datasets from the Datasets tab

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -92,6 +92,7 @@ import {
   readDatasetRowsStore,
   datasetExistsStore,
   saveDatasetStore,
+  renameDatasetStore,
 } from "../lib/dataset/dataset-store.js";
 import {
   exportDataset,
@@ -1761,6 +1762,76 @@ const server = createServer(
             ...(append ? { appended: true, added } : {}),
           }),
         );
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: formatErrorDetails(err) }));
+      }
+      return;
+    }
+
+    // API: rename a dataset. Only the file's base name moves — the directory
+    // (and so family/kind) is unchanged. Body: { path, name }.
+    if (url.pathname === "/api/datasets/rename" && req.method === "POST") {
+      try {
+        const repoRoot = join(import.meta.dirname, "..");
+        const tenant = ctx?.tenantId ?? "";
+        const body = JSON.parse(await readBody(req)) as {
+          path?: string;
+          name?: string;
+        };
+        const fromPath = String(body.path ?? "");
+        const fromAbs = resolvePath(repoRoot, fromPath);
+        if (
+          !fromPath ||
+          !fromAbs.startsWith(join(repoRoot, "data", "datasets")) ||
+          !fromAbs.endsWith(".json")
+        ) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ error: "path must be a .json under data/datasets/" }),
+          );
+          return;
+        }
+        // Sanitize to the same charset the generator allows for `out` names.
+        const safeName = String(body.name ?? "")
+          .trim()
+          .replace(/\.json$/i, "")
+          .replace(/[^a-z0-9._-]/gi, "-")
+          // collapse runs and trim separators so "My Name!" -> "My-Name"
+          .replace(/-{2,}/g, "-")
+          .replace(/^[-_.]+|[-_.]+$/g, "");
+        if (!safeName) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "name is required" }));
+          return;
+        }
+        const dir = fromPath.slice(0, fromPath.lastIndexOf("/"));
+        const toPath = `${dir}/${safeName}.json`;
+        if (toPath === fromPath) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ path: fromPath, name: safeName, unchanged: true }));
+          return;
+        }
+        if (await datasetExistsStore(tenant, toPath)) {
+          res.writeHead(409, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ error: `a dataset named "${safeName}" already exists` }),
+          );
+          return;
+        }
+        const summary = await renameDatasetStore(tenant, fromPath, toPath);
+        if (!summary) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: `dataset not found: ${fromPath}` }));
+          return;
+        }
+        if (ctx) {
+          await logAudit(ctx, "dataset.rename", "dataset", fromPath, {
+            to: toPath,
+          });
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ path: summary.path, name: summary.name }));
       } catch (err) {
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: formatErrorDetails(err) }));

--- a/dashboard/ui/src/api/datasets.ts
+++ b/dashboard/ui/src/api/datasets.ts
@@ -196,6 +196,14 @@ export function estimateGenerationCost(params: {
   return apiFetch<CostEstimate>(`/api/datasets/cost?${q.toString()}`);
 }
 
+/** Rename a dataset (its base name only — the family/kind directory is kept). */
+export function renameDataset(body: { path: string; name: string }) {
+  return apiFetch<{ path: string; name: string }>("/api/datasets/rename", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
 /** Fetch a dataset rendered in an interop format (jsonl | csv) as text. */
 export function fetchDatasetExport(path: string, format: "jsonl" | "csv") {
   return apiFetch<string>(

--- a/dashboard/ui/src/pages/DatasetsPage/index.tsx
+++ b/dashboard/ui/src/pages/DatasetsPage/index.tsx
@@ -8,6 +8,7 @@ import {
   listGenerationEngines,
   getDatasetTaxonomy,
   saveDatasetRows,
+  renameDataset,
   estimateGenerationCost,
   fetchDatasetExport,
   listProfiles,
@@ -47,6 +48,7 @@ import {
   ArrowRight,
   Download,
   Copy,
+  Pencil,
 } from "lucide-react";
 
 const PRESETS: Record<string, string> = {
@@ -211,7 +213,13 @@ function RowItem({ row }: { row: DatasetRow }) {
 }
 
 /** A dataset summary card that expands to show its rows on demand. */
-function DatasetCard({ d }: { d: DatasetSummary }) {
+function DatasetCard({
+  d,
+  onChanged,
+}: {
+  d: DatasetSummary;
+  onChanged: () => void;
+}) {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const [rows, setRows] = useState<DatasetRow[] | null>(null);
@@ -221,6 +229,28 @@ function DatasetCard({ d }: { d: DatasetSummary }) {
   const [exporting, setExporting] = useState<"jsonl" | "csv" | null>(null);
   const [showEvalCmd, setShowEvalCmd] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [draftName, setDraftName] = useState(d.name);
+  const [savingName, setSavingName] = useState(false);
+
+  const submitRename = async () => {
+    const next = draftName.trim();
+    if (!next || next === d.name) {
+      setRenaming(false);
+      return;
+    }
+    setSavingName(true);
+    setErr(null);
+    try {
+      await renameDataset({ path: d.path, name: next });
+      setRenaming(false);
+      onChanged();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setSavingName(false);
+    }
+  };
 
   // Quality datasets are scored by the CLI quality scorer (a different pipeline
   // than the red-team scan), so we surface the exact command instead of a
@@ -282,7 +312,64 @@ function DatasetCard({ d }: { d: DatasetSummary }) {
       <div className="p-3 flex items-start justify-between gap-4">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <span className="font-medium text-sm text-foreground">{d.name}</span>
+            {renaming ? (
+              <span className="flex items-center gap-1">
+                <Input
+                  className="h-7 text-sm w-44"
+                  value={draftName}
+                  autoFocus
+                  disabled={savingName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") submitRename();
+                    if (e.key === "Escape") {
+                      setDraftName(d.name);
+                      setRenaming(false);
+                    }
+                  }}
+                />
+                <Button
+                  size="sm"
+                  className="h-7"
+                  onClick={submitRename}
+                  disabled={savingName}
+                >
+                  {savingName ? (
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  ) : (
+                    <CheckCircle2 className="w-3.5 h-3.5" />
+                  )}
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7"
+                  disabled={savingName}
+                  onClick={() => {
+                    setDraftName(d.name);
+                    setRenaming(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 group">
+                <span className="font-medium text-sm text-foreground">{d.name}</span>
+                <button
+                  type="button"
+                  title="Rename dataset"
+                  className="text-muted-foreground hover:text-foreground opacity-60 group-hover:opacity-100"
+                  onClick={() => {
+                    setDraftName(d.name);
+                    setRenaming(true);
+                  }}
+                >
+                  <Pencil className="w-3 h-3" />
+                </button>
+              </span>
+            )}
             <Badge variant="outline">{d.family}</Badge>
             <Badge variant={d.kind === "quality" ? "secondary" : "outline"}>
               {d.kind}
@@ -1495,7 +1582,7 @@ export function DatasetsPage() {
           ) : (
             <div className="space-y-3">
               {datasets.map((d) => (
-                <DatasetCard key={d.path} d={d} />
+                <DatasetCard key={d.path} d={d} onChanged={refresh} />
               ))}
             </div>
           )}

--- a/lib/dataset/dataset-store.ts
+++ b/lib/dataset/dataset-store.ts
@@ -16,6 +16,7 @@ import {
   writeFileSync,
   mkdirSync,
   existsSync,
+  renameSync,
   rmSync,
 } from "node:fs";
 import { query, isDbConfigured } from "../db.js";
@@ -141,6 +142,37 @@ export async function saveDatasetStore(
     ],
   );
   return summary;
+}
+
+/**
+ * Rename a dataset (move it to a new logical path). The directory — and so the
+ * family/kind — is unchanged; only the file's base name moves. Callers must
+ * check the destination is free first (datasetExistsStore).
+ */
+export async function renameDatasetStore(
+  tenantId: string,
+  fromPath: string,
+  toPath: string,
+): Promise<DatasetSummary | null> {
+  const name = toPath.split("/").pop()!.replace(/\.json$/i, "");
+  if (!isDbConfigured()) {
+    const fromAbs = absFor(fromPath);
+    const toAbs = absFor(toPath);
+    if (!existsSync(fromAbs)) return null;
+    mkdirSync(dirname(toAbs), { recursive: true });
+    renameSync(fromAbs, toAbs);
+    const parsed = JSON.parse(readFileSync(toAbs, "utf-8"));
+    return summarizeRows(toPath, Array.isArray(parsed) ? parsed : []);
+  }
+  const res = await query<{ one: number }>(
+    `UPDATE datasets SET path = $3, name = $4, updated_at = now()
+      WHERE tenant_id = $1 AND path = $2
+      RETURNING 1 AS one`,
+    [tenantId, fromPath, toPath, name],
+  );
+  if (res.rows.length === 0) return null;
+  const rows = (await readDatasetRowsStore(tenantId, toPath)) ?? [];
+  return summarizeRows(toPath, rows);
 }
 
 /** Delete a dataset from whichever backend holds it. */

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -125,6 +125,11 @@ const PERMISSIONS: RoutePermission[] = [
     roles: ["admin"],
   },
   {
+    method: "POST",
+    pattern: /^\/api\/datasets\/rename$/,
+    roles: ["admin"],
+  },
+  {
     // Runs the quality scorer against a live target — admin-only like /api/run.
     method: "POST",
     pattern: /^\/api\/datasets\/eval-quality$/,

--- a/tests/dataset-store.test.ts
+++ b/tests/dataset-store.test.ts
@@ -8,6 +8,7 @@ import {
   listDatasetsStore,
   datasetExistsStore,
   deleteDatasetStore,
+  renameDatasetStore,
   datasetDbEnabled,
 } from "../lib/dataset/dataset-store.js";
 
@@ -69,5 +70,34 @@ describe.skipIf(datasetDbEnabled())("dataset-store (file mode)", () => {
     await deleteDatasetStore(TENANT, PATH);
     expect(await datasetExistsStore(TENANT, PATH)).toBe(false);
     expect(await readDatasetRowsStore(TENANT, PATH)).toBeNull();
+  });
+
+  it("rename moves the dataset, keeps its rows, and frees the old path", async () => {
+    const rows = [
+      { category: "tool_misuse", name: "c1", prompt: "p1", severity: "high", successCriteria: "sc" },
+    ];
+    await saveDatasetStore(TENANT, PATH, rows);
+    const RENAMED = "data/datasets/__store_test__/v2-renamed.json";
+
+    const summary = await renameDatasetStore(TENANT, PATH, RENAMED);
+    expect(summary?.path).toBe(RENAMED);
+    expect(summary?.name).toBe("v2-renamed");
+    expect(summary?.rowCount).toBe(1);
+    // family/kind are derived from the directory, so they survive the rename.
+    expect(summary?.kind).toBe("security");
+
+    expect(await datasetExistsStore(TENANT, RENAMED)).toBe(true);
+    expect(await datasetExistsStore(TENANT, PATH)).toBe(false);
+    const back = await readDatasetRowsStore(TENANT, RENAMED);
+    expect((back![0] as { prompt: string }).prompt).toBe("p1");
+  });
+
+  it("renaming a dataset that doesn't exist returns null", async () => {
+    const missing = await renameDatasetStore(
+      TENANT,
+      "data/datasets/__store_test__/nope.json",
+      "data/datasets/__store_test__/other.json",
+    );
+    expect(missing).toBeNull();
   });
 });

--- a/tests/rbac-datasets.test.ts
+++ b/tests/rbac-datasets.test.ts
@@ -42,6 +42,11 @@ describe("RBAC for dataset/eval endpoints (regression: login-loop 403)", () => {
     expect(checkPermission("POST", "/api/mcp-discover", "viewer")).toBe(false);
     expect(checkPermission("POST", "/api/mcp-discover", "auditor")).toBe(false);
   });
+  it("restricts dataset rename to admin", () => {
+    expect(checkPermission("POST", "/api/datasets/rename", "admin")).toBe(true);
+    expect(checkPermission("POST", "/api/datasets/rename", "viewer")).toBe(false);
+    expect(checkPermission("POST", "/api/datasets/rename", "auditor")).toBe(false);
+  });
   it("restricts curated save to admin", () => {
     expect(checkPermission("POST", "/api/datasets/save", "admin")).toBe(true);
     expect(checkPermission("POST", "/api/datasets/save", "viewer")).toBe(false);


### PR DESCRIPTION
Generated datasets were stuck with whatever version name they were created with ("v1"), with no way to relabel them.

Each dataset card's name is now editable in place: click the pencil, type a new name, Enter (or Save) to commit, Escape to cancel. Only the base name moves — the directory stays, so family/kind and the row data are untouched.

- new renameDatasetStore() handles both backends: fs.rename in file mode, an UPDATE of path+name in Postgres.
- POST /api/datasets/rename validates containment (data/datasets/*.json), sanitizes the name to the same charset the generator allows (collapsing runs and trimming separators), 409s if the target name is taken, 404s if the source is missing, and writes an audit entry.
- rbac: admin-only, like the other dataset writes.

Verified: 579 tests green (new store + RBAC tests); live E2E — seed → rename "My Renamed v2!" -> "My-Renamed-v2", list shows only the new name, rows still readable at the new path, and renaming onto an existing name returns 409.