### PR TITLE
fix(evals): parse target responses generically instead of String()-in…

### DIFF
--- a/dashboard/ui/src/pages/EvaluationsPage/index.tsx
+++ b/dashboard/ui/src/pages/EvaluationsPage/index.tsx
@@ -278,6 +278,21 @@ function CopyButton({ text, title }: { text: string; title?: string }) {
   );
 }
 
+/**
+ * Render any value as readable text. Rows can carry structured references /
+ * responses (and older rows even stored the literal string "[object Object]"),
+ * so never rely on the value already being a string.
+ */
+function asText(v: unknown): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
 /** A labeled block of monospace text with a copy button. */
 function TraceField({ label, value }: { label: string; value: string }) {
   if (!value) return null;
@@ -433,17 +448,17 @@ function ResultTrace({ r, index }: { r: QualityResultRow; index: number }) {
           )}
 
           <div className="grid gap-2 md:grid-cols-2">
-            <TraceField label="Input (sent to endpoint)" value={r.row.input ?? ""} />
+            <TraceField label="Input (sent to endpoint)" value={asText(r.row.input)} />
             <TraceField
               label="Expected"
               value={
                 r.row.expectedTools && r.row.expectedTools.length
                   ? `tools: ${r.row.expectedTools.join(", ")}`
-                  : (r.row.reference ?? "")
+                  : asText(r.row.reference)
               }
             />
           </div>
-          <TraceField label="Endpoint response" value={r.response ?? ""} />
+          <TraceField label="Endpoint response" value={asText(r.response)} />
           {hasTools && (
             <ToolDiff
               expected={r.row.expectedTools ?? []}

--- a/lib/dataset/to-text.ts
+++ b/lib/dataset/to-text.ts
@@ -1,0 +1,46 @@
+/**
+ * Coerce an arbitrary value to text WITHOUT collapsing structure to
+ * "[object Object]".
+ *
+ * Generated references and target responses can be anything — a plain string,
+ * an object, an array of content blocks, a provider-specific envelope. Naive
+ * `String(v)` turns every object into "[object Object]", which silently
+ * destroys the content (and then gets stored in the dataset / scored / shown in
+ * the trace). This keeps the information: known text-bearing shapes are
+ * unwrapped, and anything else is pretty-printed JSON.
+ */
+export function toText(v: unknown): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+
+  if (Array.isArray(v)) {
+    // Content-block arrays: [{type:"text",text:"…"}, …] or plain strings.
+    const parts = v.map((el) => {
+      if (el == null) return "";
+      if (typeof el === "string") return el;
+      if (typeof el === "number" || typeof el === "boolean") return String(el);
+      if (typeof el === "object") {
+        const o = el as Record<string, unknown>;
+        if (typeof o.text === "string") return o.text;
+        if (typeof o.content === "string") return o.content;
+      }
+      return "";
+    });
+    if (parts.some((p) => p.trim())) return parts.filter((p) => p.trim()).join("\n");
+    return JSON.stringify(v, null, 2);
+  }
+
+  if (typeof v === "object") {
+    const o = v as Record<string, unknown>;
+    if (typeof o.text === "string") return o.text;
+    if (typeof o.content === "string") return o.content;
+    if (Array.isArray(o.content)) {
+      const inner = toText(o.content);
+      if (inner.trim()) return inner;
+    }
+    return JSON.stringify(v, null, 2);
+  }
+
+  return String(v);
+}

--- a/lib/dataset/validate.ts
+++ b/lib/dataset/validate.ts
@@ -10,6 +10,7 @@
 import { createHash } from "node:crypto";
 import { isAttackCategory } from "./category-set.js";
 import { isQualityTask, isQualityMetric } from "./quality-set.js";
+import { toText } from "./to-text.js";
 import type {
   DatasetRow,
   QualityRow,
@@ -143,7 +144,9 @@ export function validateQualityRows(
     const task = String(o.task ?? "").trim();
     const input = String(o.input ?? "").trim();
     const metric = String(o.metric ?? "").trim();
-    const reference = String(o.reference ?? "").trim();
+    // A generated reference may come back structured (an object/array). Plain
+    // String() would store it as "[object Object]" and destroy the content.
+    const reference = toText(o.reference).trim();
     const expectedTools = Array.isArray(o.expectedTools)
       ? (o.expectedTools as unknown[]).map((t) => String(t).trim()).filter(Boolean)
       : [];

--- a/lib/quality/response-text.ts
+++ b/lib/quality/response-text.ts
@@ -1,0 +1,97 @@
+/**
+ * Pull the assistant's text out of an arbitrary target response.
+ *
+ * A target can answer in any shape: a bare string, `{message}`, `{data:{content}}`,
+ * an OpenAI-style `{choices:[{message:{content}}]}`, MCP content blocks, or a
+ * streamed SSE body. The scorer previously did
+ * `String(extractPath(body, responsePath) ?? "")`, which yields "[object Object]"
+ * for structured values and "" whenever the configured path doesn't match — so a
+ * perfectly good answer got scored as empty.
+ *
+ * Strategy: honor the configured `responsePath` first (explicit config wins),
+ * then try the common envelopes, and finally fall back to the whole body as
+ * JSON. Anything is better than "" — an operator can see what came back and fix
+ * their responsePath, instead of debugging a blank.
+ */
+import { extractPath } from "../response-analyzer.js";
+import { toText } from "../dataset/to-text.js";
+
+/** Common places a response text hides, tried in order. */
+const FALLBACK_PATHS = [
+  "response",
+  "message",
+  "content",
+  "text",
+  "answer",
+  "output",
+  "result",
+  "reply",
+  "data.message",
+  "data.content",
+  "data.text",
+  "data.response",
+  "choices.0.message.content",
+  "choices.0.text",
+  "candidates.0.content.parts.0.text",
+];
+
+/**
+ * Join a streamed SSE body into one string. Handles OpenAI-style
+ * `data: {"choices":[{"delta":{"content":"…"}}]}` frames and plain
+ * `data: <text>` lines. Returns "" when the body isn't SSE.
+ */
+export function parseSseText(raw: string): string {
+  if (!/(^|\n)\s*data:/.test(raw)) return "";
+  const out: string[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const m = /^\s*data:\s?(.*)$/.exec(line);
+    if (!m) continue;
+    const payload = m[1].trim();
+    if (!payload || payload === "[DONE]") continue;
+    if (payload.startsWith("{") || payload.startsWith("[")) {
+      try {
+        const obj = JSON.parse(payload) as Record<string, unknown>;
+        // streamed delta, then non-streamed shapes, then any text-bearing field
+        const delta =
+          extractPath(obj, "choices.0.delta.content") ??
+          extractPath(obj, "choices.0.message.content") ??
+          extractPath(obj, "delta.text") ??
+          extractPath(obj, "content") ??
+          extractPath(obj, "text");
+        const t = toText(delta);
+        if (t) out.push(t);
+        continue;
+      } catch {
+        /* not JSON — fall through and take it literally */
+      }
+    }
+    out.push(payload);
+  }
+  return out.join("");
+}
+
+/**
+ * Extract response text from an arbitrary body.
+ * @param responsePath the operator-configured path (wins when it resolves)
+ */
+export function extractResponseText(body: unknown, responsePath?: string): string {
+  // A raw streamed body arrives as text.
+  if (typeof body === "string") {
+    const sse = parseSseText(body);
+    if (sse.trim()) return sse;
+    if (body.trim()) return body;
+  }
+
+  if (responsePath) {
+    const t = toText(extractPath(body, responsePath));
+    if (t.trim()) return t;
+  }
+
+  for (const p of FALLBACK_PATHS) {
+    const t = toText(extractPath(body, p));
+    if (t.trim()) return t;
+  }
+
+  // Nothing matched — show the whole body rather than a blank.
+  return toText(body);
+}

--- a/lib/quality/scorer.ts
+++ b/lib/quality/scorer.ts
@@ -16,6 +16,7 @@ import { executeAttack } from "../attack-runner.js";
 import { extractPath } from "../response-analyzer.js";
 import { describeTarget } from "../target-adapter.js";
 import { runQualityMcpAgent } from "./mcp-agent.js";
+import { extractResponseText } from "./response-text.js";
 import { DETERMINISTIC_METRICS, scoreDeterministic } from "./metrics.js";
 import { judgeQuality, isJudgeMetric } from "./judge.js";
 import type { Attack, Config } from "../types.js";
@@ -94,8 +95,11 @@ export async function scoreQualityRow(
       const res = await executeAttack(config, attack);
       statusCode = res.statusCode;
       timeMs = res.timeMs;
-      responseText = String(
-        extractPath(res.body, config.responseSchema.responsePath) ?? "",
+      // Targets answer in arbitrary shapes (and may stream) — resolve the
+      // configured path first, then common envelopes, never "[object Object]".
+      responseText = extractResponseText(
+        res.body,
+        config.responseSchema.responsePath,
       );
       actualTools = extractToolNames(
         res.body,

--- a/tests/quality-response-text.test.ts
+++ b/tests/quality-response-text.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { toText } from "../lib/dataset/to-text.js";
+import {
+  extractResponseText,
+  parseSseText,
+} from "../lib/quality/response-text.js";
+
+describe("toText", () => {
+  it("passes strings and scalars through", () => {
+    expect(toText("hi")).toBe("hi");
+    expect(toText(42)).toBe("42");
+    expect(toText(true)).toBe("true");
+    expect(toText(null)).toBe("");
+    expect(toText(undefined)).toBe("");
+  });
+
+  it("never produces [object Object]", () => {
+    const out = toText({ severity: "high", cwe: "CWE-89" });
+    expect(out).not.toContain("[object Object]");
+    expect(JSON.parse(out)).toEqual({ severity: "high", cwe: "CWE-89" });
+  });
+
+  it("unwraps MCP-style content blocks", () => {
+    expect(
+      toText([
+        { type: "text", text: "line one" },
+        { type: "text", text: "line two" },
+      ]),
+    ).toBe("line one\nline two");
+  });
+
+  it("unwraps { text } and { content } objects", () => {
+    expect(toText({ text: "answer" })).toBe("answer");
+    expect(toText({ content: "answer" })).toBe("answer");
+    expect(toText({ content: [{ text: "a" }, { text: "b" }] })).toBe("a\nb");
+  });
+
+  it("joins scalar arrays as lines", () => {
+    expect(toText([1, 2, 3])).toBe("1\n2\n3");
+    expect(toText(["a", "b"])).toBe("a\nb");
+  });
+
+  it("pretty-prints arrays whose entries carry no text", () => {
+    const out = toText([{ id: 1 }, { id: 2 }]);
+    expect(out).not.toContain("[object Object]");
+    expect(JSON.parse(out)).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+});
+
+describe("parseSseText", () => {
+  it("joins OpenAI-style streamed deltas", () => {
+    const raw = [
+      'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+      'data: {"choices":[{"delta":{"content":", world"}}]}',
+      "data: [DONE]",
+    ].join("\n");
+    expect(parseSseText(raw)).toBe("Hello, world");
+  });
+
+  it("handles plain data: lines", () => {
+    expect(parseSseText("data: alpha\ndata: beta")).toBe("alphabeta");
+  });
+
+  it("returns empty for non-SSE text", () => {
+    expect(parseSseText("just a normal answer")).toBe("");
+  });
+});
+
+describe("extractResponseText", () => {
+  it("honors the configured responsePath first", () => {
+    const body = { answer: "configured", message: "fallback" };
+    expect(extractResponseText(body, "answer")).toBe("configured");
+  });
+
+  it("falls back to common envelopes when the path misses", () => {
+    // responsePath points at a field this target doesn't use.
+    expect(extractResponseText({ message: "hi there" }, "answer")).toBe("hi there");
+    expect(
+      extractResponseText({ choices: [{ message: { content: "gpt style" } }] }),
+    ).toBe("gpt style");
+    expect(extractResponseText({ data: { content: "nested" } })).toBe("nested");
+  });
+
+  it("stringifies a structured response instead of [object Object]", () => {
+    const body = { response: { findings: [{ id: 101, severity: "high" }] } };
+    const out = extractResponseText(body, "response");
+    expect(out).not.toContain("[object Object]");
+    expect(out).toContain("101");
+  });
+
+  it("returns the whole body when nothing matches, never empty", () => {
+    const body = { totally: { unexpected: "shape" } };
+    const out = extractResponseText(body, "answer");
+    expect(out).not.toBe("");
+    expect(out).toContain("unexpected");
+  });
+
+  it("parses a streamed body", () => {
+    const raw = 'data: {"choices":[{"delta":{"content":"streamed"}}]}\ndata: [DONE]';
+    expect(extractResponseText(raw, "answer")).toBe("streamed");
+  });
+
+  it("passes a plain string body through", () => {
+    expect(extractResponseText("bare text", "answer")).toBe("bare text");
+  });
+});


### PR DESCRIPTION
…g them

Two places coerced arbitrary values with String(), which turns any object into the literal "[object Object]" — destroying the content, not just its display:

  - validate.ts stored a generated `reference` that came back structured as "[object Object]" IN the dataset (visible as EXPECTED in the trace view).
  - scorer.ts read the target's answer as String(extractPath(body, responsePath) ?? ""), so a structured response became "[object Object]" and a responsePath that didn't match the target's shape produced "" — the judge then scored an empty string as wrong.

Targets answer in any shape, so extraction is now layered:
  1. the operator-configured responsePath (explicit config still wins)
  2. common envelopes — message / content / text / answer / data.* / choices.0.message.content / candidates.0.content.parts.0.text
  3. the whole body as pretty JSON — never a blank

New toText() unwraps text-bearing shapes (MCP content blocks, {text}, {content}) and pretty-prints anything else as JSON. New parseSseText() joins streamed SSE bodies (OpenAI-style delta frames and plain `data:` lines) so a streaming endpoint is scored on its assembled answer.

The Evaluations trace also renders defensively, so rows already saved with "[object Object]" don't break the view.

Note: rows generated before this fix have the damaged reference baked in and need regenerating. 594 tests green (15 new).