### PR TITLE
feat(scans): name scans at launch and rename them anytime

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -1398,6 +1398,65 @@ const server = createServer(
       return;
     }
 
+    // PATCH /api/run/:id — rename a run (update the user-given name). The name
+    // lives in the run's config JSON, so no schema change is needed: we update
+    // the in-memory job, the saved config file, and the DB config JSONB.
+    if (url.pathname.startsWith("/api/run/") && req.method === "PATCH") {
+      const id = url.pathname.slice("/api/run/".length);
+      let name = "";
+      try {
+        const body = JSON.parse(await readBody(req));
+        name = typeof body?.name === "string" ? body.name.trim().slice(0, 120) : "";
+      } catch {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid body" }));
+        return;
+      }
+
+      const job = jobs.get(id);
+      let found = !!job;
+
+      // In-memory job: mutate its config and persist the saved-config file.
+      if (job) {
+        job.config.name = name || undefined;
+        saveRunConfig(id, job.config);
+      } else {
+        // Historical run: update the saved config file if present.
+        const cfg = await loadRunConfig(id, ctx?.tenantId);
+        if (cfg) {
+          cfg.name = name || undefined;
+          saveRunConfig(id, cfg);
+        }
+      }
+
+      // DB: set config.name (jsonb_set), or clear it when the name is empty.
+      if (isDbConfigured() && ctx?.tenantId) {
+        try {
+          const upd = await query(
+            name
+              ? `UPDATE runs SET config = jsonb_set(COALESCE(config, '{}'::jsonb), '{name}', to_jsonb($1::text), true)
+                   WHERE id=$2 AND tenant_id=$3 RETURNING id`
+              : `UPDATE runs SET config = (COALESCE(config, '{}'::jsonb) - 'name')
+                   WHERE id=$2 AND tenant_id=$3 RETURNING id`,
+            name ? [name, id, ctx.tenantId] : [null, id, ctx.tenantId],
+          );
+          if (upd.rows.length > 0) found = true;
+        } catch (err) {
+          console.error(`  [RENAME] DB update failed for ${id}:`, err);
+        }
+      }
+
+      if (!found) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Run not found" }));
+        return;
+      }
+      if (ctx) await logAudit(ctx, "run.rename", "run", id, { name });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ runId: id, name: name || null }));
+      return;
+    }
+
     // DELETE /api/run/:id — cancel a running job (or ?purge=1 to remove it)
     if (url.pathname.startsWith("/api/run/") && req.method === "DELETE") {
       const id = url.pathname.slice("/api/run/".length);
@@ -1498,6 +1557,7 @@ const server = createServer(
             status: getJobStatus(j),
             startedAt: j.startedAt,
             finishedAt: j.finishedAt,
+            name: j.config?.name,
             targetUrl: describeTarget(j.config),
             error: j._cancelled ? "Cancelled by user" : j.error,
             // progress is a mixed stream of phase/message events (clone, plan,
@@ -1514,7 +1574,8 @@ const server = createServer(
       if (isDbConfigured() && ctx?.tenantId) {
         try {
           const dbRuns = await query(
-            `SELECT id, status, target_url, started_at, finished_at, error
+            `SELECT id, status, target_url, started_at, finished_at, error,
+                    config->>'name' AS name
              FROM runs WHERE tenant_id = $1 ORDER BY started_at DESC LIMIT 100`,
             [ctx.tenantId],
           );
@@ -1537,6 +1598,7 @@ const server = createServer(
                 status: orphanedActive ? "error" : rawStatus,
                 startedAt,
                 finishedAt,
+                name: row.name || undefined,
                 targetUrl: row.target_url || "unknown",
                 error: orphanedActive
                   ? row.error || "Interrupted — server restarted before completion"

--- a/dashboard/ui/src/api/runs.ts
+++ b/dashboard/ui/src/api/runs.ts
@@ -11,6 +11,13 @@ export function getRun(id: string, since = 0, includeConfig = false) {
   return apiFetch<RunDetail>(`/api/run/${id}?${params}`);
 }
 
+export function renameRun(id: string, name: string) {
+  return apiFetch<{ runId: string; name: string | null }>(`/api/run/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ name }),
+  });
+}
+
 export function createRun(config: Record<string, unknown>) {
   return apiFetch<{ runId: string; status: string; estimatedTotal?: number }>(
     "/api/run",

--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -217,6 +217,7 @@ export default function NewScanPage() {
   const [activeTemplate, setActiveTemplate] = useState<string | null>(null);
 
   // ── Target ──
+  const [scanName, setScanName] = useState("");
   const [targetType, setTargetType] = useState<"http_agent" | "mcp" | "websocket_agent">("http_agent");
   const [baseUrl, setBaseUrl] = useState("");
   const [agentEndpoint, setAgentEndpoint] = useState("/api/agent");
@@ -369,6 +370,9 @@ export default function NewScanPage() {
     const atk = c.attackConfig as Record<string, unknown> | undefined;
     const reqSchema = c.requestSchema as Record<string, unknown> | undefined;
     const resSchema = c.responseSchema as Record<string, unknown> | undefined;
+
+    // Scan name
+    if (typeof c.name === "string") setScanName(c.name);
 
     // Target
     if (target?.baseUrl) setBaseUrl(String(target.baseUrl));
@@ -564,6 +568,7 @@ export default function NewScanPage() {
     }
 
     const config: Record<string, unknown> = {
+      ...(scanName.trim() ? { name: scanName.trim() } : {}),
       target,
       auth: {
         methods: authMethods,
@@ -948,6 +953,18 @@ export default function NewScanPage() {
           <SectionHeader step={2} title="Configure target" icon={Target} />
           <Card>
             <CardContent className="pt-5 space-y-4">
+              {/* Scan name (optional) */}
+              <FieldRow label="Scan name" hint="Optional — a friendly label for this scan (shown in Scan Activity)">
+                <input
+                  type="text"
+                  value={scanName}
+                  onChange={(e) => setScanName(e.target.value)}
+                  placeholder="e.g. HR agent — nightly regression"
+                  maxLength={120}
+                  className={inputCls}
+                />
+              </FieldRow>
+
               {/* Target Type */}
               <FieldRow label="Target Type">
                 <div className="flex gap-2">

--- a/dashboard/ui/src/pages/RunsPage/index.tsx
+++ b/dashboard/ui/src/pages/RunsPage/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router";
-import { getRuns, getRun, deleteRun, createRun } from "@/api/runs";
+import { getRuns, getRun, deleteRun, createRun, renameRun } from "@/api/runs";
 import type { RunMeta, RunDetail } from "@/api/types";
 import { usePolling } from "@/hooks/usePolling";
 import {
@@ -20,6 +20,9 @@ import {
   ChevronRight,
   Loader2,
   Search,
+  Pencil,
+  Check,
+  X,
 } from "lucide-react";
 import { useDebounce } from "@/hooks/useDebounce";
 
@@ -193,6 +196,42 @@ export default function RunsPage() {
   );
 
   // Delete run
+  // Inline rename of a scan.
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [nameDraft, setNameDraft] = useState("");
+  const [savingName, setSavingName] = useState(false);
+
+  const startRename = useCallback((run: RunMeta, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRenamingId(run.runId);
+    setNameDraft(run.name ?? "");
+  }, []);
+
+  const cancelRename = useCallback(() => {
+    setRenamingId(null);
+    setNameDraft("");
+  }, []);
+
+  const saveRename = useCallback(
+    async (runId: string) => {
+      const name = nameDraft.trim();
+      setSavingName(true);
+      try {
+        await renameRun(runId, name);
+        setRuns((prev) =>
+          prev.map((r) => (r.runId === runId ? { ...r, name: name || undefined } : r)),
+        );
+        setRenamingId(null);
+        setNameDraft("");
+      } catch (err) {
+        console.error("Failed to rename run:", err);
+      } finally {
+        setSavingName(false);
+      }
+    },
+    [nameDraft],
+  );
+
   const handleDelete = useCallback(
     async (runId: string, e: React.MouseEvent) => {
       e.stopPropagation();
@@ -350,12 +389,59 @@ export default function RunsPage() {
 
                   {/* Title + meta */}
                   <div className="min-w-0 flex-1">
-                    <h3
-                      className="text-sm font-semibold text-foreground truncate"
-                      title={run.targetUrl ?? ""}
-                    >
-                      {title}
-                    </h3>
+                    {renamingId === run.runId ? (
+                      <div
+                        className="flex items-center gap-1.5"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <input
+                          autoFocus
+                          value={nameDraft}
+                          onChange={(e) => setNameDraft(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") saveRename(run.runId);
+                            if (e.key === "Escape") cancelRename();
+                          }}
+                          placeholder="Name this scan…"
+                          className="h-7 min-w-0 flex-1 max-w-xs rounded border border-border bg-background px-2 text-sm"
+                        />
+                        <button
+                          onClick={() => saveRename(run.runId)}
+                          disabled={savingName}
+                          title="Save name"
+                          className="p-1 rounded text-emerald-600 dark:text-emerald-400 hover:bg-muted disabled:opacity-50"
+                        >
+                          {savingName ? (
+                            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                          ) : (
+                            <Check className="w-3.5 h-3.5" />
+                          )}
+                        </button>
+                        <button
+                          onClick={cancelRename}
+                          title="Cancel"
+                          className="p-1 rounded text-muted-foreground hover:bg-muted"
+                        >
+                          <X className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="group/name flex items-center gap-1.5 min-w-0">
+                        <h3
+                          className="text-sm font-semibold text-foreground truncate"
+                          title={run.targetUrl ?? ""}
+                        >
+                          {title}
+                        </h3>
+                        <button
+                          onClick={(e) => startRename(run, e)}
+                          title={run.name ? "Rename scan" : "Name this scan"}
+                          className="shrink-0 p-0.5 rounded text-muted-foreground/50 hover:text-foreground hover:bg-muted opacity-0 group-hover/name:opacity-100 transition-opacity"
+                        >
+                          <Pencil className="w-3 h-3" />
+                        </button>
+                      </div>
+                    )}
                     <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap">
                       <span className={`font-semibold uppercase tracking-wide ${cfg.textColor}`}>
                         {cfg.label}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -438,6 +438,8 @@ export interface McpTargetConfig {
 }
 
 export interface Config {
+  /** Optional user-given name for this scan (shown in Scan Activity). */
+  name?: string;
   target: {
     /** Execution target type. Defaults to "http_agent". */
     type?: TargetType;


### PR DESCRIPTION
Scans can now carry a friendly name. No DB migration: the name lives in the run's existing config JSONB (config.name).

- Config.name added to the type; loadConfigFromObject already passes unknown fields through, so it survives to the job and DB
- Launch Scan: optional "Scan name" field, written to config.name and restored on Edit & Rerun
- GET /api/runs returns name (config.name for live jobs; config->>'name' for historical DB rows)
- PATCH /api/run/:id renames a run — updates the in-memory job, the saved config file, and the DB config via jsonb_set (audited)
- Scan Activity: inline rename (pencil → input → save/cancel), and search now matches the name too