### PR TITLE
feat(scans): only show the eval-dataset picker when a dataset is in play

### DIFF
--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -1922,10 +1922,15 @@ export default function NewScanPage() {
             </div>
           </CollapsibleSection>
 
+          {/* Only shown when a dataset is actually in play: quality mode (a
+              dataset is required) or arriving from the Datasets tab's "Use for
+              evaluation" (?dataset=…). A plain "New Scan" hides it — the dataset
+              list would be noise (and unwieldy with many datasets). */}
+          {(mode === "quality" || !!deepLinkDataset) && (
           <CollapsibleSection
             title="Evaluation Dataset"
             icon={FileText}
-            defaultOpen={!!deepLinkDataset || mode === "quality"}
+            defaultOpen
           >
             <div className="space-y-4">
               <FieldRow
@@ -1999,6 +2004,7 @@ export default function NewScanPage() {
               )}
             </div>
           </CollapsibleSection>
+          )}
         </div>
 
         {/* ═══ Advanced JSON override ═══ */}


### PR DESCRIPTION
The "Evaluation Dataset" section listed every dataset as a chip, which gets unwieldy with many datasets and is noise on a plain security scan.

Now it renders only when a dataset is actually relevant:
- quality-eval mode (a dataset is required), or
- arriving from the Datasets tab's "Use for evaluation" (?dataset=…).

A plain "New Scan" no longer shows it.