### PR TITLE
feat(compliance): clean layout + map attack categories & tactics to controls

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -3386,6 +3386,7 @@ const server = createServer(
           code: m.code,
           title: m.title,
           description: m.description,
+          categories: m.categories,
           status: m.status,
           attacksAnalyzed: m.totalAttacks,
           passed: m.passed,

--- a/dashboard/ui/src/api/types.ts
+++ b/dashboard/ui/src/api/types.ts
@@ -187,6 +187,8 @@ export interface ComplianceFramework {
 export interface ComplianceControlAttack {
   name: string;
   category: string;
+  /** Delivery strategy / tactic used (e.g. crescendo, roleplay). */
+  strategy?: string;
   severity: string;
   verdict: "PASS" | "PARTIAL" | "FAIL";
   detail?: string;
@@ -202,6 +204,9 @@ export interface ComplianceResult {
   details?: string;
   recommendations?: string[];
   attacksAnalyzed?: number;
+  /** Attack categories this control maps to (coverage basis) — present even for
+   *  not_tested controls so the UI can show what would exercise the control. */
+  categories?: string[];
   /** Per-attack breakdown for this control, returned by the static-mapping
    *  endpoint. Lets the UI associate controls back to individual vulnerabilities
    *  (each attack carries the category the control maps against). */

--- a/dashboard/ui/src/pages/CompliancePage/index.tsx
+++ b/dashboard/ui/src/pages/CompliancePage/index.tsx
@@ -98,6 +98,29 @@ function truncateUrl(url: string, max = 32): string {
   }
 }
 
+/** snake_case attack category/tactic \u2192 "Title Case". */
+function pretty(s: string): string {
+  return s.replace(/[_-]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const VERDICT_STYLE: Record<string, { dot: string; label: string; text: string }> = {
+  PASS: { dot: "bg-red-500", label: "Vulnerable", text: "text-red-600 dark:text-red-400" },
+  PARTIAL: { dot: "bg-orange-500", label: "At risk", text: "text-orange-600 dark:text-orange-400" },
+  FAIL: { dot: "bg-emerald-500", label: "Defended", text: "text-emerald-600 dark:text-emerald-400" },
+};
+
+/** A small neutral chip for categories / tactics. */
+function Chip({ children, title }: { children: React.ReactNode; title?: string }) {
+  return (
+    <span
+      title={title}
+      className="inline-flex items-center rounded-md border border-border bg-muted/50 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+    >
+      {children}
+    </span>
+  );
+}
+
 /* ---------- component ---------- */
 
 export default function CompliancePage() {
@@ -345,23 +368,30 @@ export default function CompliancePage() {
                   </button>
                 </div>
               </div>
-              <div className="flex flex-wrap gap-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-2">
                 {frameworks.map((fw) => {
                   const selected = selectedFrameworks.has(fw.id);
                   return (
                     <button
                       key={fw.id}
                       onClick={() => toggleFramework(fw.id)}
-                      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-all ${
+                      title={fw.name}
+                      className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium border text-left transition-all ${
                         selected
-                          ? "bg-primary text-white border-primary shadow-sm"
+                          ? "bg-primary/5 text-foreground border-primary/50 ring-1 ring-primary/20"
                           : "bg-card text-muted-foreground border-border hover:border-muted-foreground/30 hover:text-foreground"
                       }`}
                     >
-                      {selected && <CheckCircle className="w-3 h-3" />}
-                      {fw.name}
-                      <span className={selected ? "text-white/70" : "text-muted-foreground"}>
-                        ({fw.controlCount})
+                      <span
+                        className={`grid place-items-center w-4 h-4 rounded shrink-0 border ${
+                          selected ? "bg-primary border-primary text-white" : "border-border"
+                        }`}
+                      >
+                        {selected && <CheckCircle className="w-3 h-3" />}
+                      </span>
+                      <span className="truncate flex-1">{fw.name}</span>
+                      <span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
+                        {fw.controlCount}
                       </span>
                     </button>
                   );
@@ -483,10 +513,13 @@ export default function CompliancePage() {
                       const details = r.details?.trim();
                       const recommendations = r.recommendations ?? [];
                       const findings = r.findings ?? [];
+                      const attacks = r.attacks ?? [];
+                      const categories = r.categories ?? [];
                       const hasAnalysis =
                         !!details || recommendations.length > 0 || findings.length > 0;
+                      const hasDetail = hasAnalysis || attacks.length > 0;
                       return (
-                        <div key={`${r.code}-${i}`} className="py-3 first:pt-0 last:pb-0">
+                        <div key={`${r.code}-${i}`} className="py-3.5 first:pt-0 last:pb-0">
                           <div className="flex items-start gap-3">
                             <div className="flex-1 min-w-0">
                               <div className="flex items-center gap-2 mb-1">
@@ -496,16 +529,67 @@ export default function CompliancePage() {
                                 <span className="text-sm font-medium text-foreground">{r.title}</span>
                               </div>
                               <p className="text-xs text-muted-foreground mt-0.5">{r.summary}</p>
+                              {/* category → control mapping (shown even when not tested) */}
+                              {categories.length > 0 && (
+                                <div className="mt-2 flex flex-wrap items-center gap-1">
+                                  <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70 mr-0.5">
+                                    Maps to
+                                  </span>
+                                  {categories.map((c) => (
+                                    <Chip key={c} title={c}>
+                                      {pretty(c)}
+                                    </Chip>
+                                  ))}
+                                </div>
+                              )}
                             </div>
                             <StatusBadge status={r.status} />
                           </div>
-                          {hasAnalysis && (
+                          {hasDetail && (
                             <details className="mt-2 group">
                               <summary className="cursor-pointer text-xs font-medium text-primary hover:underline list-none inline-flex items-center gap-1">
                                 <ChevronRight className="w-3 h-3 transition-transform group-open:rotate-90" />
-                                Detailed analysis
+                                {attacks.length > 0
+                                  ? `${attacks.length} attack${attacks.length === 1 ? "" : "s"} exercised this control`
+                                  : "Detailed analysis"}
                               </summary>
                               <div className="mt-2 space-y-3 pl-4 border-l-2 border-border">
+                                {attacks.length > 0 && (
+                                  <div className="space-y-1.5">
+                                    {attacks.map((a, j) => {
+                                      const v = VERDICT_STYLE[a.verdict] ?? VERDICT_STYLE.FAIL;
+                                      return (
+                                        <div
+                                          key={j}
+                                          className="flex items-start gap-2 text-xs"
+                                          title={a.detail}
+                                        >
+                                          <span
+                                            className={`mt-1.5 w-1.5 h-1.5 rounded-full shrink-0 ${v.dot}`}
+                                          />
+                                          <div className="min-w-0 flex-1">
+                                            <div className="flex flex-wrap items-center gap-1.5">
+                                              <span className="text-foreground/90 truncate">
+                                                {a.name}
+                                              </span>
+                                              <Chip title={`category: ${a.category}`}>
+                                                {pretty(a.category)}
+                                              </Chip>
+                                              {a.strategy && (
+                                                <Chip title={`tactic: ${a.strategy}`}>
+                                                  ⚔ {pretty(a.strategy)}
+                                                </Chip>
+                                              )}
+                                              <span className={`font-medium ${v.text}`}>
+                                                {v.label}
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      );
+                                    })}
+                                  </div>
+                                )}
                                 {details && (
                                   <p className="text-xs text-muted-foreground whitespace-pre-wrap leading-relaxed">
                                     {details}

--- a/lib/report-generator.ts
+++ b/lib/report-generator.ts
@@ -310,6 +310,7 @@ export function mapResultsToCompliance(
         .map((r) => ({
           name: r.attack.name,
           category: r.attack.category,
+          strategy: r.attack.strategyName,
           severity: r.attack.severity,
           verdict: r.verdict as "PASS" | "PARTIAL" | "FAIL",
           detail: (r.llmReasoning || r.findings[0] || "").slice(0, 280),
@@ -321,6 +322,7 @@ export function mapResultsToCompliance(
         code: item.code,
         title: item.title,
         description: item.description,
+        categories: item.categories,
         totalAttacks: mapped.length,
         passed: passCount,
         partial: partialCount,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -926,6 +926,8 @@ export interface Report {
 export interface ComplianceMappedAttack {
   name: string;
   category: AttackCategory;
+  /** Delivery strategy / tactic used to craft the attack (e.g. crescendo, roleplay). */
+  strategy?: string;
   severity: "critical" | "high" | "medium" | "low";
   verdict: "PASS" | "PARTIAL" | "FAIL";
   /** Short finding / judge reasoning — why the attack succeeded or was blocked. */
@@ -944,6 +946,9 @@ export interface ComplianceResult {
   failed: number;
   status: "vulnerable" | "at_risk" | "secure" | "not_tested";
   findings: string[];
+  /** Attack categories this control maps to — the basis for coverage, shown
+   *  even when the control is not_tested so users see what WOULD exercise it. */
+  categories?: AttackCategory[];
   /** Every attack mapped to this control (reason = category ∈ control scope). */
   attacks: ComplianceMappedAttack[];
 }


### PR DESCRIPTION
## Summary

Two changes to the **Compliance** page: a cleaner layout, and surfacing which attack **categories and tactics** map to each control.

## 1. Cleaner layout
- The framework selector is now a uniform **responsive grid** (checkbox rows, truncated names, control counts) instead of ragged wrapping pills — the main "uneven" culprit.
- Tidier per-control rows and spacing.

## 2. Map attack categories & tactics to controls
- Every control shows a **"Maps to"** row of its mapped attack categories (from the framework definition) — shown **even when `not_tested`**, so users see what *would* exercise the control.
- Expanding a control ("N attacks exercised this control") lists each attack with its **category chip**, a **⚔ tactic chip** (the delivery strategy — Roleplay, Crescendo, Encoding, …), and verdict (Vulnerable / At risk / Defended).

## Backend
- `mapResultsToCompliance` now carries `item.categories` and each attack's `strategyName`.
- The static-compliance endpoint passes `categories` through.
- Types updated: `ComplianceResult.categories`, `ComplianceMappedAttack.strategy` (+ UI `ComplianceControlAttack.strategy`). Additive — existing reports keep working.

## Verification
Rendered live against fixtures: the framework grid, the "Maps to" category rows (incl. a not_tested control), and the expanded attacks with category + tactic + verdict. Root + UI typecheck (exit 0) and UI build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
