### PR TITLE
feat(compliance): framework presets + live coverage on scan & dataset pickers

### DIFF
--- a/dashboard/ui/src/api/types.ts
+++ b/dashboard/ui/src/api/types.ts
@@ -294,11 +294,23 @@ export interface GuardrailResult {
 }
 
 // ── Reference ──
+/** One compliance control an attack category maps to (from /api/reference). */
+export interface CategoryComplianceRef {
+  framework: string;
+  code: string;
+  title: string;
+}
+export interface ReferenceFramework {
+  id: string;
+  name: string;
+  controlCount: number;
+}
 export interface ReferenceData {
   categories: string[];
   strategies: StrategyInfo[];
-  categoryCompliance: Record<string, string[]>;
-  frameworks?: { name: string; items: unknown[] }[];
+  /** category → the compliance controls it covers (reverse mapping). */
+  categoryCompliance: Record<string, CategoryComplianceRef[]>;
+  frameworks?: ReferenceFramework[];
   /** Whether this instance permits MCP stdio targets (self-hosted only). */
   allowMcpStdio?: boolean;
   /** Categories that have native MCP attacks (used to scope the form for MCP targets). */

--- a/dashboard/ui/src/components/shared/CompliancePresets.tsx
+++ b/dashboard/ui/src/components/shared/CompliancePresets.tsx
@@ -1,0 +1,146 @@
+import { Shield, CheckCircle } from "lucide-react";
+import type { CategoryComplianceRef, ReferenceFramework } from "@/api/types";
+
+/** Compact label for a (long) compliance framework name — drops the trailing
+ *  "(Regulation …)" and long subtitles so preset chips stay tidy. */
+export function shortFramework(name: string): string {
+  const base = name.split(/[(—-]| - /)[0].trim();
+  return base.length > 34 ? base.slice(0, 33) + "…" : base;
+}
+
+/**
+ * Compliance-framework presets over an attack-category picker.
+ *
+ * Frameworks map to CATEGORIES (what to test), never to tactics (how to deliver),
+ * so selecting a framework simply ADDS the union of categories its controls map
+ * to — additive, because one category can serve many frameworks. Below the
+ * presets we show the forward view: how many of each framework's controls the
+ * current selection will actually exercise.
+ *
+ * Powered entirely by the `categoryCompliance` reverse index from /api/reference,
+ * so it needs no extra data beyond what the picker already loads.
+ */
+export function CompliancePresets({
+  frameworks,
+  categoryCompliance,
+  selectableCategories,
+  selected,
+  onAdd,
+  className = "",
+}: {
+  frameworks: ReferenceFramework[];
+  categoryCompliance: Record<string, CategoryComplianceRef[]>;
+  /** Categories the user can actually pick (e.g. scoped to MCP or a taxonomy). */
+  selectableCategories: string[];
+  /** Currently-selected categories. */
+  selected: string[];
+  /** Add these categories to the selection (additive, dedup handled by caller). */
+  onAdd: (categories: string[]) => void;
+  className?: string;
+}) {
+  if (!frameworks.length) return null;
+
+  // framework → its mapped categories, and → its controls (code → categories).
+  const fwCats: Record<string, Set<string>> = {};
+  const fwControls: Record<string, Record<string, Set<string>>> = {};
+  const selectable = new Set(selectableCategories);
+  for (const [cat, refs] of Object.entries(categoryCompliance)) {
+    if (!selectable.has(cat)) continue;
+    for (const cr of refs) {
+      (fwCats[cr.framework] ??= new Set()).add(cat);
+      ((fwControls[cr.framework] ??= {})[cr.code] ??= new Set()).add(cat);
+    }
+  }
+
+  const selectedSet = new Set(selected);
+  const categoriesFor = (fwName: string) => [...(fwCats[fwName] ?? [])];
+  const coveredControls = (fwName: string) =>
+    Object.values(fwControls[fwName] ?? {}).filter((cats) =>
+      [...cats].some((c) => selectedSet.has(c)),
+    ).length;
+
+  // Only frameworks that have at least one selectable category are actionable.
+  const actionable = frameworks.filter((fw) => (fwCats[fw.name]?.size ?? 0) > 0);
+  if (actionable.length === 0) return null;
+
+  const coverageRows = actionable
+    .map((fw) => ({ fw, covered: coveredControls(fw.name) }))
+    .filter((r) => r.covered > 0);
+
+  return (
+    <div
+      className={`rounded-lg border border-dashed border-border p-3 space-y-2.5 ${className}`}
+    >
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <span className="text-xs font-medium text-foreground flex items-center gap-1.5">
+          <Shield className="w-3.5 h-3.5 text-primary" />
+          Target a compliance framework
+        </span>
+        <span className="text-[11px] text-muted-foreground">
+          adds the attack categories its controls map to
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {actionable.map((fw) => {
+          const cats = categoriesFor(fw.name);
+          const allSel = cats.every((c) => selectedSet.has(c));
+          return (
+            <button
+              key={fw.id}
+              type="button"
+              title={`${fw.name} — ${cats.length} categories across ${fw.controlCount} controls`}
+              onClick={() => onAdd(cats)}
+              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-medium border transition-all ${
+                allSel
+                  ? "bg-primary/10 border-primary/40 text-foreground"
+                  : "bg-card text-muted-foreground border-border hover:border-muted-foreground/30 hover:text-foreground"
+              }`}
+            >
+              {allSel && <CheckCircle className="w-3 h-3 text-primary" />}
+              {shortFramework(fw.name)}
+              <span className="text-muted-foreground">+{cats.length}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {coverageRows.length > 0 && (
+        <div className="pt-1 border-t border-border/60">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70 mb-1.5">
+            Coverage from your selection
+          </p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1">
+            {coverageRows.map(({ fw, covered }) => (
+              <span
+                key={fw.id}
+                className="text-[11px] text-muted-foreground"
+                title={fw.name}
+              >
+                <span className="font-medium text-foreground">
+                  {shortFramework(fw.name)}
+                </span>{" "}
+                <span
+                  className={
+                    covered >= fw.controlCount
+                      ? "text-emerald-600 dark:text-emerald-400 tabular-nums"
+                      : "tabular-nums"
+                  }
+                >
+                  {covered}/{fw.controlCount}
+                </span>{" "}
+                controls
+              </span>
+            ))}
+          </div>
+          <p className="text-[10px] text-muted-foreground/70 mt-1.5">
+            Controls with no testable category stay “Not Tested”. Coverage ≠
+            certification — it reflects what your attacks exercise.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CompliancePresets;

--- a/dashboard/ui/src/pages/DatasetsPage/index.tsx
+++ b/dashboard/ui/src/pages/DatasetsPage/index.tsx
@@ -23,6 +23,9 @@ import {
   type CostEstimate,
 } from "@/api/datasets";
 import { ProfileWizard } from "./ProfileWizard";
+import { getReference } from "@/api/reference";
+import { CompliancePresets } from "@/components/shared/CompliancePresets";
+import type { CategoryComplianceRef, ReferenceFramework } from "@/api/types";
 import { useNavigate } from "react-router";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -596,6 +599,11 @@ export function DatasetsPage() {
   const [trends, setTrends] = useState<EvalTrend[]>([]);
   const [loading, setLoading] = useState(true);
   const [kind, setKind] = useState<"security" | "quality">("security");
+  // Compliance-framework mapping (for the security-focus presets), loaded once.
+  const [frameworks, setFrameworks] = useState<ReferenceFramework[]>([]);
+  const [categoryCompliance, setCategoryCompliance] = useState<
+    Record<string, CategoryComplianceRef[]>
+  >({});
   const [family, setFamily] = useState<"mcp" | "agent">("mcp");
   const [providers, setProviders] = useState<GenerationProvider[]>(
     FALLBACK_PROVIDERS,
@@ -682,6 +690,13 @@ export function DatasetsPage() {
             (m) => r.engines.find((e) => e.id === "openai")?.defaultModel ?? m,
           );
         }
+      })
+      .catch(() => {});
+    // Compliance mapping powers the security-focus framework presets.
+    getReference()
+      .then((r) => {
+        setFrameworks(r.frameworks ?? []);
+        setCategoryCompliance(r.categoryCompliance ?? {});
       })
       .catch(() => {});
   }, []);
@@ -1207,6 +1222,20 @@ export function DatasetsPage() {
                   <Label className="text-xs">
                     Focus (optional) — leave empty to cover the full set
                   </Label>
+                  {/* Compliance-framework presets — generate rows for the categories
+                      a framework's controls map to. Security datasets only (quality
+                      datasets focus on tasks, which don't map to frameworks). */}
+                  {kind === "security" && frameworks.length > 0 && (
+                    <CompliancePresets
+                      frameworks={frameworks}
+                      categoryCompliance={categoryCompliance}
+                      selectableCategories={primary}
+                      selected={selCategories}
+                      onAdd={(cats) =>
+                        setSelCategories((prev) => [...new Set([...prev, ...cats])])
+                      }
+                    />
+                  )}
                   <div className="space-y-1">
                     <span className="text-[11px] text-muted-foreground">
                       {primaryLabel}

--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from "react-router";
 import { createRun, getRuns } from "@/api/runs";
 import type { RunMeta } from "@/api/types";
 import { getReference, discoverMcp } from "@/api/reference";
+import { CompliancePresets } from "@/components/shared/CompliancePresets";
 import { apiFetch } from "@/api/client";
 import {
   listDatasets,
@@ -131,6 +132,7 @@ const TEMPLATES = [
 function prettyCat(cat: string) {
   return cat.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
+
 
 function SectionHeader({
   step,
@@ -1328,6 +1330,21 @@ export default function NewScanPage() {
             <SectionHeader step={3} title="Select attack categories" icon={Crosshair} />
             <Card>
               <CardContent className="pt-5">
+                {/* Compliance-framework presets — select the union of categories a
+                    framework's controls map to, and preview forward coverage. */}
+                {ref.frameworks && ref.frameworks.length > 0 && (
+                  <CompliancePresets
+                    className="mb-5"
+                    frameworks={ref.frameworks}
+                    categoryCompliance={ref.categoryCompliance}
+                    selectableCategories={selectableCategories}
+                    selected={selectedCategories}
+                    onAdd={(cats) =>
+                      setSelectedCategories((prev) => [...new Set([...prev, ...cats])])
+                    }
+                  />
+                )}
+
                 <div className="flex items-center justify-between mb-4">
                   <span className="text-xs text-muted-foreground">
                     {selectedCategories.length}/{selectableCategories.length} selected


### PR DESCRIPTION
## Summary

Users can now **select attack categories from a compliance framework** and **preview coverage before running** — on both the **Launch Scan** category step and the **Datasets** generation focus. No backend change: it's powered by the `categoryCompliance` reverse index already returned by `/api/reference`.

## The model (why it's shaped this way)

Frameworks map to **categories** (*what* to test), never to **tactics** (*how* to deliver) — so a framework is a **preset that adds** the union of categories its controls map to. It's additive, not a filter, because one category serves many frameworks.

## What's included

- **New shared `<CompliancePresets>` component** — one source of truth for both pages:
  - Framework chips add the categories a framework's controls map to, scoped to the selectable set (MCP mode, or a dataset taxonomy). A chip shows a check + `+N` once its categories are selected.
  - **"Coverage from your selection"** readout: per framework, how many of its controls the current selection exercises (`X/Y`), with the honest caveat that untested controls stay *Not Tested* and coverage ≠ certification.
- **Launch Scan** — presets on "Select attack categories".
- **Datasets** — presets on the security-focus picker (quality datasets focus on *tasks*, which don't map to frameworks, so it's security-only).
- Fixes `ReferenceData.categoryCompliance` to the real runtime shape (`category → {framework, code, title}[]`).

## Verification
Rendered live on both pages: framework chips select the mapped categories, the coverage readout updates per framework, and the honest caveat shows. Types + UI build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
