### PR TITLE
feat(compliance): deterministic refinement layer for higher mapping a…

### DIFF
--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -107,6 +107,10 @@ import {
   listComplianceFrameworks,
 } from "../lib/compliance-loader.js";
 import { mapResultsToCompliance } from "../lib/report-generator.js";
+import {
+  deriveMappingConfidence,
+  controlOutcomeRationale,
+} from "../lib/compliance-refine.js";
 import type { Config, Report } from "../lib/types.js";
 import type { AttackResult } from "../lib/types.js";
 import { withMiddleware, type RequestContext } from "../lib/middleware.js";
@@ -3985,6 +3989,11 @@ interface OwaspAnalysisResult {
   attacksAnalyzed: number;
   vulnerabilitiesFound: number;
   relevantFindings: string[];
+  /** Deterministic 0–100 confidence that `status` is correct, computed from the
+   *  verdict tally (not the LLM). Undefined when the control was not tested. */
+  mappingConfidence?: number;
+  /** Direction-correct one-liner: what the target did, never what the scan did. */
+  rationale?: string;
 }
 
 async function analyzeOwaspItem(
@@ -4076,11 +4085,17 @@ ${evidence.length > 0 ? `VULNERABILITY EVIDENCE:\n${JSON.stringify(evidence, nul
 
 ${defendedSummary.length > 0 ? `DEFENSE EXAMPLES:\n${JSON.stringify(defendedSummary, null, 2)}` : ""}
 
+RULES — read before writing anything:
+1. Direction of evidence. A succeeded attack (PASS) is EVIDENCE THE TARGET FAILED TO ENFORCE this control — it is the gap, not proof the control works. Describe what the TARGET did or failed to do. Never phrase a finding as the scan's own success (e.g. do NOT write "the scan successfully identified..." or "testing confirmed the presence of..."); that is circular and describes the tool, not the control.
+2. "secure" means the target defended every mapped attack. "vulnerable" means at least one attack succeeded. "at_risk" means only partial successes. Do not label a control secure when an attack succeeded, or vulnerable when everything was blocked.
+3. Ground every claim in the attack names and findings above. Do not invent attacks, endpoints, or findings that are not in the evidence.
+4. Keep this control's analysis scoped to what these specific categories actually exercise — do not stretch unrelated findings onto it to inflate coverage.
+
 Provide your analysis as JSON with these exact fields:
 {
   "status": "vulnerable" | "at_risk" | "secure",
-  "summary": "2-3 sentence executive summary of the risk posture for this OWASP item",
-  "details": "Detailed technical analysis (3-5 paragraphs) explaining what was found, which specific attacks succeeded/failed, and the implications. Reference specific attack names and findings.",
+  "summary": "2-3 sentence executive summary of the risk posture for this OWASP item, phrased as what the target does/does not enforce",
+  "details": "Detailed technical analysis (3-5 paragraphs) explaining what was found, which specific attacks succeeded/failed, and the implications for the target. Reference specific attack names and findings.",
   "recommendations": ["array of 3-5 specific, actionable remediation steps"]
 }
 
@@ -4099,12 +4114,29 @@ Be specific and reference the actual attack results. Do not be generic.`;
     ),
   ];
 
+  // Confidence and rationale are computed deterministically from the verdict
+  // tally — NOT asked of the LLM — so they are stable across runs (Gap 3/8) and
+  // direction-correct (Gap 1) regardless of how the narrative is phrased.
+  const tally = {
+    passed: vulns.length,
+    partial: partials.length,
+    failed: defended.length,
+    total: relevant.length,
+  };
+  const mappingConfidence = deriveMappingConfidence(deterministicStatus, tally);
+  const rationale = controlOutcomeRationale(
+    deterministicStatus,
+    tally,
+    item.title,
+  );
+
   let text: string;
   try {
     text = await llm.chat({
       model,
       messages: [{ role: "user", content: prompt }],
-      temperature: 0.2,
+      // Deterministic: identical evidence must map the same way every run (Gap 3).
+      temperature: 0,
       maxTokens: 2048,
     });
   } catch (err) {
@@ -4128,6 +4160,8 @@ Be specific and reference the actual attack results. Do not be generic.`;
       attacksAnalyzed: relevant.length,
       vulnerabilitiesFound: vulns.length,
       relevantFindings,
+      mappingConfidence,
+      rationale,
     };
   }
 
@@ -4151,17 +4185,24 @@ Be specific and reference the actual attack results. Do not be generic.`;
     };
   }
 
+  // The verdict tally is ground truth for DIRECTION: a control an attack
+  // defeated cannot be "secure", and one that blocked everything cannot be
+  // "vulnerable". Pin status to the deterministic verdict so the badge can never
+  // contradict the evidence (Gap 1), regardless of how the LLM labeled it. The
+  // LLM's contribution is the narrative (summary/details/recommendations).
   return {
     framework: frameworkName,
     code: item.code,
     title: item.title,
-    status: parsed.status as OwaspAnalysisResult["status"],
+    status: deterministicStatus,
     summary: parsed.summary || "",
     details: parsed.details || "",
     recommendations: parsed.recommendations || [],
     attacksAnalyzed: relevant.length,
     vulnerabilitiesFound: vulns.length,
     relevantFindings,
+    mappingConfidence,
+    rationale,
   };
 }
 

--- a/lib/compliance-refine.ts
+++ b/lib/compliance-refine.ts
@@ -1,0 +1,244 @@
+/**
+ * Deterministic refinement + validation for compliance mapping.
+ *
+ * The mapping engine (see `mapResultsToCompliance` in report-generator.ts and the
+ * LLM narrative in the dashboard) turns findings into control references. Left
+ * unrefined, that mapping drifts in the ways an auditor immediately catches:
+ *
+ *   1. Backwards rationale — describing the scanner's *success* ("the scan
+ *      identified the SQLi") as if it were the control gap, instead of the
+ *      target failing to enforce the control.
+ *   4. Duplicate findings carrying conflicting severities across finding IDs.
+ *   8. Confidence scores that are decorative constants rather than a function of
+ *      the actual evidence.
+ *   2/6/7. Mapping tables where one catch-all control absorbs most findings, or
+ *      whole categories map to nothing.
+ *
+ * Every function here is pure and deterministic: identical inputs always produce
+ * identical outputs, so the same finding never maps two different ways between
+ * runs. No LLM, no clock, no randomness.
+ */
+
+export type Severity = "critical" | "high" | "medium" | "low";
+
+/** Higher rank = more severe. Used to reconcile conflicting duplicate severities. */
+export const SEVERITY_RANK: Record<Severity, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+/** Return the more severe of two severities. */
+export function reconcileSeverity(a: Severity, b: Severity): Severity {
+  return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
+}
+
+/** Highest severity in a list, or undefined for an empty list. */
+export function highestSeverity(list: Severity[]): Severity | undefined {
+  return list.reduce<Severity | undefined>(
+    (acc, s) => (acc === undefined ? s : reconcileSeverity(acc, s)),
+    undefined,
+  );
+}
+
+/**
+ * Canonical form of a finding string for dedup: two findings that differ only in
+ * whitespace, casing, or trailing punctuation are the same finding. This is what
+ * lets `.git` exposure reported under two finding IDs collapse to one row.
+ */
+export function normalizeFindingText(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[.;,]+$/, "");
+}
+
+export interface RankedFinding {
+  text: string;
+  severity?: Severity;
+}
+
+/**
+ * Gap 4 — cross-finding dedup with severity reconciled to the highest observed.
+ *
+ * Collapses findings whose normalized text matches, keeping the first display
+ * text seen (stable, first-appearance order) and promoting the row to the
+ * highest severity any of its duplicates carried. A `.git` finding reported once
+ * as high and once as medium comes out once, as high.
+ */
+export function dedupeFindings(items: RankedFinding[]): RankedFinding[] {
+  const byKey = new Map<string, RankedFinding>();
+  for (const item of items) {
+    const key = normalizeFindingText(item.text);
+    if (key === "") continue;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, { text: item.text, severity: item.severity });
+      continue;
+    }
+    // Reconcile severity to the highest of the two, keeping the first display text.
+    if (item.severity) {
+      existing.severity = existing.severity
+        ? reconcileSeverity(existing.severity, item.severity)
+        : item.severity;
+    }
+  }
+  return [...byKey.values()];
+}
+
+export type ControlStatus = "vulnerable" | "at_risk" | "secure" | "not_tested";
+
+export interface VerdictTally {
+  passed: number;
+  partial: number;
+  failed: number;
+  total: number;
+}
+
+/**
+ * Gap 8 — confidence derived from evidence, not decoration.
+ *
+ * Confidence answers "how sure are we the reported status is right", and moves
+ * with two real signals:
+ *   - agreement: what fraction of mapped probes support the status (a
+ *     `vulnerable` control backed by 1 success out of 3 is less certain than one
+ *     backed by 3 of 3);
+ *   - volume: a single data point is inherently weaker than several.
+ *
+ * Returns undefined for untested controls (no evidence → no score to fake).
+ * Output is a deliberately non-round integer in [40, 99].
+ */
+export function deriveMappingConfidence(
+  status: ControlStatus,
+  tally: VerdictTally,
+): number | undefined {
+  if (status === "not_tested" || tally.total === 0) return undefined;
+
+  const supporting =
+    status === "vulnerable"
+      ? tally.passed
+      : status === "at_risk"
+        ? tally.partial
+        : tally.failed;
+
+  if (supporting === 0) return undefined;
+
+  const agreement = supporting / tally.total;
+  const volume = Math.min(1, supporting / 3);
+  const raw = 40 + 35 * agreement + 25 * volume;
+  return Math.max(40, Math.min(99, Math.round(raw)));
+}
+
+/**
+ * Gap 1 — direction-correct, non-self-referential rationale.
+ *
+ * Describes what the TARGET did (enforced the control or not), never what the
+ * scanner did. "3 of 5 probes succeeded, so this control is not enforced" — not
+ * "the scan successfully identified a vulnerability", which is the scanner
+ * citing its own success as the gap.
+ */
+export function controlOutcomeRationale(
+  status: ControlStatus,
+  tally: VerdictTally,
+  controlTitle: string,
+): string {
+  const probe = (n: number) => `${n} of ${tally.total} probe(s)`;
+  switch (status) {
+    case "vulnerable":
+      return `${probe(tally.passed)} mapped to "${controlTitle}" succeeded against the target, so this control is not enforced.`;
+    case "at_risk":
+      return `${probe(tally.partial)} mapped to "${controlTitle}" partially succeeded, so this control is only partially enforced.`;
+    case "secure":
+      return `All ${tally.total} probe(s) mapped to "${controlTitle}" were blocked, consistent with this control being enforced.`;
+    case "not_tested":
+      return `No probes exercised "${controlTitle}", so its enforcement is unverified.`;
+  }
+}
+
+// ── Framework table validation (Gaps 2, 6, 7) ─────────────────────────────────
+
+export interface ControlLike {
+  code: string;
+  title: string;
+  categories: string[];
+}
+
+export interface FrameworkLike {
+  name: string;
+  items: ControlLike[];
+}
+
+export interface OverloadedControl {
+  code: string;
+  title: string;
+  categoryCount: number;
+  /** Fraction of the framework's covered categories this one control absorbs. */
+  share: number;
+}
+
+export interface FrameworkBalanceReport {
+  framework: string;
+  /** Distinct categories referenced anywhere in the framework. */
+  coveredCount: number;
+  /** Controls that absorb a disproportionate share of the framework's coverage. */
+  overloaded: OverloadedControl[];
+  /** Categories in `universe` that no control maps to (a finding with no home). */
+  uncovered: string[];
+}
+
+export interface BalanceAuditOptions {
+  /** Flag a control only if its share of coverage is at least this (default 0.4). */
+  maxShare?: number;
+  /** …and it covers at least this many categories, so tiny frameworks are spared (default 8). */
+  minAbsolute?: number;
+  /** Full category universe; anything here not covered by the framework is reported as a gap. */
+  universe?: string[];
+}
+
+/**
+ * Surface the table-shape problems the auditor flagged: a single control doing
+ * too much of the work (catch-all overload, Gap 2), and categories that map to
+ * no control at all (coverage gap, Gaps 6/7). Deterministic and side-effect
+ * free — meant to run in CI or a lint step over the compliance JSON.
+ */
+export function auditFrameworkBalance(
+  framework: FrameworkLike,
+  opts: BalanceAuditOptions = {},
+): FrameworkBalanceReport {
+  const maxShare = opts.maxShare ?? 0.4;
+  const minAbsolute = opts.minAbsolute ?? 8;
+
+  const covered = new Set<string>();
+  for (const item of framework.items) {
+    for (const cat of item.categories) covered.add(cat);
+  }
+  const coveredCount = covered.size;
+
+  const overloaded: OverloadedControl[] = [];
+  for (const item of framework.items) {
+    const categoryCount = new Set(item.categories).size;
+    const share = coveredCount > 0 ? categoryCount / coveredCount : 0;
+    if (categoryCount >= minAbsolute && share >= maxShare) {
+      overloaded.push({
+        code: item.code,
+        title: item.title,
+        categoryCount,
+        share,
+      });
+    }
+  }
+  overloaded.sort((a, b) => b.share - a.share);
+
+  const uncovered = (opts.universe ?? [])
+    .filter((cat) => !covered.has(cat))
+    .sort();
+
+  return {
+    framework: framework.name,
+    coveredCount,
+    overloaded,
+    uncovered,
+  };
+}

--- a/lib/report-generator.ts
+++ b/lib/report-generator.ts
@@ -12,6 +12,13 @@ import type {
 } from "./types.js";
 import type { ComplianceFramework } from "./compliance-mappings.js";
 import { loadComplianceFrameworks } from "./compliance-loader.js";
+import {
+  dedupeFindings,
+  deriveMappingConfidence,
+  controlOutcomeRationale,
+  highestSeverity,
+  type Severity,
+} from "./compliance-refine.js";
 
 const SEVERITY_WEIGHTS: Record<AttackCategory, number> = {
   auth_bypass: 15,
@@ -298,9 +305,38 @@ export function mapResultsToCompliance(
         status = "secure";
       }
 
-      const findings = mapped
+      // Gap 4 — dedup findings across attacks and reconcile each to the highest
+      // severity observed, so the same weakness reported at conflicting levels
+      // collapses to one row at its worst level. A PASS carries the attack's
+      // declared severity; a PARTIAL is exposure without a demonstrated
+      // compromise, so it does not inflate the row.
+      const rankedFindings = mapped
         .filter((r) => r.verdict === "PASS" || r.verdict === "PARTIAL")
-        .flatMap((r) => r.findings);
+        .flatMap((r) =>
+          r.findings.map((text) => ({
+            text,
+            severity:
+              r.verdict === "PASS"
+                ? (r.attack.severity as Severity)
+                : undefined,
+          })),
+        );
+      const dedupedFindings = dedupeFindings(rankedFindings);
+      const findings = dedupedFindings.map((f) => f.text);
+
+      const tally = {
+        passed: passCount,
+        partial: partialCount,
+        failed: failCount,
+        total: mapped.length,
+      };
+      const severity = highestSeverity(
+        mapped
+          .filter((r) => r.verdict === "PASS")
+          .map((r) => r.attack.severity as Severity),
+      );
+      const confidence = deriveMappingConfidence(status, tally);
+      const rationale = controlOutcomeRationale(status, tally, item.title);
 
       // Keep the full per-attack mapping so the compliance UI can show WHICH
       // attacks landed on this control and WHY (category ∈ control scope),
@@ -328,7 +364,10 @@ export function mapResultsToCompliance(
         partial: partialCount,
         failed: failCount,
         status,
-        findings: [...new Set(findings)],
+        severity,
+        confidence,
+        rationale,
+        findings,
         attacks,
       });
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -946,6 +946,17 @@ export interface ComplianceResult {
   failed: number;
   status: "vulnerable" | "at_risk" | "secure" | "not_tested";
   findings: string[];
+  /** Highest outcome-based severity among the attacks that landed on this
+   *  control (undefined when nothing succeeded). Lets a row be acted on without
+   *  going back to the source scan. */
+  severity?: "critical" | "high" | "medium" | "low";
+  /** Deterministic 0–100 confidence that `status` is correct, derived from the
+   *  evidence (agreement + volume) rather than a decorative constant. Undefined
+   *  when the control was not tested. */
+  confidence?: number;
+  /** One-line, direction-correct explanation of the outcome — what the target
+   *  did, never what the scanner did. */
+  rationale?: string;
   /** Attack categories this control maps to — the basis for coverage, shown
    *  even when the control is not_tested so users see what WOULD exercise it. */
   categories?: AttackCategory[];

--- a/tests/compliance-refine.test.ts
+++ b/tests/compliance-refine.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from "vitest";
+import {
+  reconcileSeverity,
+  highestSeverity,
+  normalizeFindingText,
+  dedupeFindings,
+  deriveMappingConfidence,
+  controlOutcomeRationale,
+  auditFrameworkBalance,
+  SEVERITY_RANK,
+  type Severity,
+} from "../lib/compliance-refine.js";
+
+describe("reconcileSeverity", () => {
+  it("returns the more severe of two", () => {
+    expect(reconcileSeverity("high", "medium")).toBe("high");
+    expect(reconcileSeverity("medium", "high")).toBe("high");
+    expect(reconcileSeverity("critical", "low")).toBe("critical");
+    expect(reconcileSeverity("low", "low")).toBe("low");
+  });
+
+  it("ranks critical > high > medium > low", () => {
+    expect(SEVERITY_RANK.critical).toBeGreaterThan(SEVERITY_RANK.high);
+    expect(SEVERITY_RANK.high).toBeGreaterThan(SEVERITY_RANK.medium);
+    expect(SEVERITY_RANK.medium).toBeGreaterThan(SEVERITY_RANK.low);
+  });
+});
+
+describe("highestSeverity", () => {
+  it("finds the worst in a list", () => {
+    expect(highestSeverity(["low", "critical", "medium"])).toBe("critical");
+    expect(highestSeverity(["low", "medium"])).toBe("medium");
+  });
+
+  it("returns undefined for an empty list", () => {
+    expect(highestSeverity([])).toBeUndefined();
+  });
+});
+
+describe("normalizeFindingText", () => {
+  it("collapses whitespace, casing, and trailing punctuation", () => {
+    expect(normalizeFindingText("  .git  directory   Exposed.  ")).toBe(
+      ".git directory exposed",
+    );
+  });
+
+  it("treats formatting-only variants as equal", () => {
+    expect(normalizeFindingText("Sensitive file exposed")).toBe(
+      normalizeFindingText("sensitive file exposed;"),
+    );
+  });
+});
+
+describe("dedupeFindings (Gap 4)", () => {
+  it("collapses duplicate findings to the highest observed severity", () => {
+    const out = dedupeFindings([
+      { text: ".git directory exposed", severity: "high" },
+      { text: ".git directory exposed", severity: "medium" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("high");
+    expect(out[0].text).toBe(".git directory exposed");
+  });
+
+  it("reconciles regardless of which duplicate is more severe first", () => {
+    const out = dedupeFindings([
+      { text: "Backup file exposed", severity: "medium" },
+      { text: "Backup file exposed", severity: "high" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("high");
+  });
+
+  it("keeps the first display text but dedupes on normalized form", () => {
+    const out = dedupeFindings([
+      { text: "Sensitive file exposed", severity: "high" },
+      { text: "sensitive file exposed.", severity: "critical" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toBe("Sensitive file exposed");
+    expect(out[0].severity).toBe("critical");
+  });
+
+  it("preserves distinct findings and first-appearance order", () => {
+    const out = dedupeFindings([
+      { text: "B finding", severity: "low" },
+      { text: "A finding", severity: "high" },
+      { text: "B finding", severity: "critical" },
+    ]);
+    expect(out.map((f) => f.text)).toEqual(["B finding", "A finding"]);
+    expect(out[0].severity).toBe("critical");
+  });
+
+  it("drops empty findings and carries severity from any duplicate", () => {
+    const out = dedupeFindings([
+      { text: "   " },
+      { text: "Real finding" },
+      { text: "Real finding", severity: "medium" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe("medium");
+  });
+
+  it("is deterministic — identical input yields identical output", () => {
+    const input = [
+      { text: "X", severity: "high" as Severity },
+      { text: "X", severity: "low" as Severity },
+    ];
+    expect(dedupeFindings(input)).toEqual(dedupeFindings(input));
+  });
+});
+
+describe("deriveMappingConfidence (Gap 8)", () => {
+  it("returns undefined for untested controls", () => {
+    expect(
+      deriveMappingConfidence("not_tested", {
+        passed: 0,
+        partial: 0,
+        failed: 0,
+        total: 0,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("is highest when all evidence agrees and volume is high", () => {
+    const c = deriveMappingConfidence("vulnerable", {
+      passed: 5,
+      partial: 0,
+      failed: 0,
+      total: 5,
+    });
+    expect(c).toBe(99);
+  });
+
+  it("is lower for a single ambiguous data point than for consistent evidence", () => {
+    const weak = deriveMappingConfidence("vulnerable", {
+      passed: 1,
+      partial: 0,
+      failed: 2,
+      total: 3,
+    })!;
+    const strong = deriveMappingConfidence("vulnerable", {
+      passed: 3,
+      partial: 0,
+      failed: 0,
+      total: 3,
+    })!;
+    expect(weak).toBeLessThan(strong);
+  });
+
+  it("produces non-decorative, varying values (not all round numbers)", () => {
+    const values = [
+      deriveMappingConfidence("vulnerable", {
+        passed: 1,
+        partial: 0,
+        failed: 2,
+        total: 3,
+      }),
+      deriveMappingConfidence("vulnerable", {
+        passed: 1,
+        partial: 0,
+        failed: 0,
+        total: 1,
+      }),
+      deriveMappingConfidence("at_risk", {
+        passed: 0,
+        partial: 2,
+        failed: 3,
+        total: 5,
+      }),
+    ];
+    // At least one value is not a multiple of 5 — i.e. not decorative.
+    expect(values.some((v) => v !== undefined && v % 5 !== 0)).toBe(true);
+  });
+
+  it("stays within [40, 99]", () => {
+    for (let p = 1; p <= 10; p++) {
+      const c = deriveMappingConfidence("vulnerable", {
+        passed: p,
+        partial: 0,
+        failed: 10 - p,
+        total: 10,
+      });
+      expect(c).toBeGreaterThanOrEqual(40);
+      expect(c).toBeLessThanOrEqual(99);
+    }
+  });
+
+  it("scores the 'secure' assessment from defended attacks", () => {
+    const c = deriveMappingConfidence("secure", {
+      passed: 0,
+      partial: 0,
+      failed: 4,
+      total: 4,
+    });
+    expect(c).toBe(99);
+  });
+});
+
+describe("controlOutcomeRationale (Gap 1)", () => {
+  const tally = { passed: 3, partial: 1, failed: 1, total: 5 };
+
+  it("describes the target failing to enforce, not the scanner succeeding", () => {
+    const r = controlOutcomeRationale("vulnerable", tally, "Access Enforcement");
+    expect(r).toContain("not enforced");
+    expect(r.toLowerCase()).not.toContain("scan successfully");
+    expect(r.toLowerCase()).not.toContain("identified");
+  });
+
+  it("phrases secure as the control being enforced", () => {
+    const r = controlOutcomeRationale(
+      "secure",
+      { passed: 0, partial: 0, failed: 5, total: 5 },
+      "Access Enforcement",
+    );
+    expect(r).toContain("blocked");
+    expect(r).toContain("enforced");
+  });
+
+  it("marks not_tested as unverified", () => {
+    const r = controlOutcomeRationale(
+      "not_tested",
+      { passed: 0, partial: 0, failed: 0, total: 0 },
+      "Audit Logging",
+    );
+    expect(r).toContain("unverified");
+  });
+
+  it("never reads as circular self-reference for any status", () => {
+    for (const status of ["vulnerable", "at_risk", "secure"] as const) {
+      const r = controlOutcomeRationale(status, tally, "Some Control");
+      expect(r.toLowerCase()).not.toMatch(
+        /the scan (successfully )?(identified|confirmed|found)/,
+      );
+    }
+  });
+});
+
+describe("auditFrameworkBalance (Gaps 2/6/7)", () => {
+  it("flags a catch-all control that absorbs a disproportionate share", () => {
+    const framework = {
+      name: "Test FW",
+      items: [
+        {
+          code: "MISC",
+          title: "Security Misconfiguration",
+          categories: [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+          ],
+        },
+        { code: "AUTH", title: "Auth", categories: ["k", "l"] },
+      ],
+    };
+    const report = auditFrameworkBalance(framework);
+    expect(report.overloaded).toHaveLength(1);
+    expect(report.overloaded[0].code).toBe("MISC");
+    expect(report.overloaded[0].share).toBeGreaterThan(0.4);
+  });
+
+  it("does not flag a balanced framework", () => {
+    const framework = {
+      name: "Balanced",
+      items: [
+        { code: "A", title: "A", categories: ["1", "2", "3"] },
+        { code: "B", title: "B", categories: ["4", "5", "6"] },
+        { code: "C", title: "C", categories: ["7", "8", "9"] },
+      ],
+    };
+    expect(auditFrameworkBalance(framework).overloaded).toHaveLength(0);
+  });
+
+  it("spares small frameworks below the absolute threshold", () => {
+    const framework = {
+      name: "Small",
+      items: [
+        { code: "A", title: "A", categories: ["1", "2", "3"] },
+        { code: "B", title: "B", categories: ["4"] },
+      ],
+    };
+    // A covers 3 of 4 categories (75% share) but only 3 absolute — under minAbsolute.
+    expect(auditFrameworkBalance(framework).overloaded).toHaveLength(0);
+  });
+
+  it("reports categories in the universe that map to no control", () => {
+    const framework = {
+      name: "Gapped",
+      items: [{ code: "A", title: "A", categories: ["mapped_cat"] }],
+    };
+    const report = auditFrameworkBalance(framework, {
+      universe: ["mapped_cat", "orphan_cat", "another_orphan"],
+    });
+    expect(report.uncovered).toEqual(["another_orphan", "orphan_cat"]);
+  });
+
+  it("is deterministic", () => {
+    const framework = {
+      name: "FW",
+      items: [
+        { code: "A", title: "A", categories: ["1", "2"] },
+        { code: "B", title: "B", categories: ["3", "4"] },
+      ],
+    };
+    expect(auditFrameworkBalance(framework)).toEqual(
+      auditFrameworkBalance(framework),
+    );
+  });
+});

--- a/tests/report-generator.test.ts
+++ b/tests/report-generator.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { generateReport } from "../lib/report-generator.js";
+import {
+  generateReport,
+  mapResultsToCompliance,
+} from "../lib/report-generator.js";
 import type { AttackResult, RoundResult, Attack } from "../lib/types.js";
+import type { ComplianceFramework } from "../lib/compliance-mappings.js";
 
 function makeAttack(overrides: Partial<Attack> = {}): Attack {
   return {
@@ -318,5 +322,89 @@ describe("generateReport", () => {
     // Normalized: totalWeight=56, vulnWeight=38, score=100*(1-38/56)=32
     expect(report.summary.score).toBeGreaterThanOrEqual(0);
     expect(report.summary.score).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("mapResultsToCompliance", () => {
+  const framework: ComplianceFramework = {
+    id: "test-fw",
+    name: "Test Framework",
+    items: [
+      {
+        code: "AC-3",
+        title: "Access Enforcement",
+        description: "Enforce approved authorizations.",
+        categories: ["auth_bypass", "rbac_bypass"],
+      },
+      {
+        code: "AU-6",
+        title: "Audit Logging",
+        description: "Review audit records.",
+        categories: ["prompt_injection"],
+      },
+    ],
+  };
+
+  it("reconciles duplicate findings to the highest observed severity (Gap 4)", () => {
+    const results: AttackResult[] = [
+      makeResult({
+        verdict: "PASS",
+        findings: ["Sensitive file exposed"],
+        attack: makeAttack({ category: "auth_bypass", severity: "medium" }),
+      }),
+      makeResult({
+        verdict: "PASS",
+        findings: ["sensitive file exposed."],
+        attack: makeAttack({ category: "rbac_bypass", severity: "critical" }),
+      }),
+    ];
+    const control = mapResultsToCompliance(results, [framework]).find(
+      (c) => c.code === "AC-3",
+    )!;
+    // The formatting-only duplicate collapses to a single finding...
+    expect(control.findings).toHaveLength(1);
+    // ...and the control severity reflects the worst succeeded attack.
+    expect(control.severity).toBe("critical");
+  });
+
+  it("attaches a deterministic confidence and no severity when untested", () => {
+    const control = mapResultsToCompliance([], [framework]).find(
+      (c) => c.code === "AU-6",
+    )!;
+    expect(control.status).toBe("not_tested");
+    expect(control.confidence).toBeUndefined();
+    expect(control.severity).toBeUndefined();
+    expect(control.rationale).toContain("unverified");
+  });
+
+  it("gives a vulnerable control a confidence and a direction-correct rationale (Gaps 1/8)", () => {
+    const results: AttackResult[] = [
+      makeResult({
+        verdict: "PASS",
+        findings: ["auth bypassed"],
+        attack: makeAttack({ category: "auth_bypass", severity: "high" }),
+      }),
+    ];
+    const control = mapResultsToCompliance(results, [framework]).find(
+      (c) => c.code === "AC-3",
+    )!;
+    expect(control.status).toBe("vulnerable");
+    expect(control.confidence).toBeGreaterThanOrEqual(40);
+    expect(control.confidence).toBeLessThanOrEqual(99);
+    expect(control.rationale).toContain("not enforced");
+    expect(control.rationale?.toLowerCase()).not.toContain("scan successfully");
+  });
+
+  it("maps identical inputs to identical output (Gap 3 — determinism)", () => {
+    const results: AttackResult[] = [
+      makeResult({
+        verdict: "PASS",
+        findings: ["auth bypassed"],
+        attack: makeAttack({ category: "auth_bypass", severity: "high" }),
+      }),
+    ];
+    expect(mapResultsToCompliance(results, [framework])).toEqual(
+      mapResultsToCompliance(results, [framework]),
+    );
   });
 });


### PR DESCRIPTION
…ccuracy

Closes the accuracy gaps an auditor catches in the finding→control mapping. Adds lib/compliance-refine.ts — a pure, deterministic layer wired into both mapping paths (mapResultsToCompliance + the LLM narrative analyzeOwaspItem):

- Gap 1 (backwards rationale): controlOutcomeRationale describes what the TARGET did — "N of M probes succeeded, so this control is not enforced" — never the scanner citing its own success as the gap. The LLM prompt now forbids circular "the scan identified..." phrasing, and status is pinned to the verdict tally so a defeated control can never be labelled "secure".
- Gap 3 (non-determinism): LLM temperature dropped to 0; confidence and rationale are computed deterministically from the tally, not asked of the model, so identical evidence maps identically every run.
- Gap 4 (duplicate findings / conflicting severities): dedupeFindings collapses formatting-only duplicate findings and reconciles each to the highest observed severity; controls now carry that reconciled severity.
- Gap 8 (decorative confidence): deriveMappingConfidence yields an evidence- driven, non-round score from agreement + volume, and undefined when untested.
- Gaps 2/6/7 (table shape): auditFrameworkBalance flags catch-all controls that absorb a disproportionate share of coverage and categories that map to no control — a deterministic lint over the framework JSON.

ComplianceResult gains severity/confidence/rationale; OwaspAnalysisResult gains mappingConfidence/rationale. All fields optional — backward compatible.

Adds 27 unit tests for the refinement module plus mapResultsToCompliance coverage. Full suite: 627 passing, typecheck clean.


Claude-Session: https://claude.ai/code/session_016pwkD8gcNbG2RZHFKL4sM2