### PR TITLE
Fix evaluation UI states, MCP headers, and report exports

### DIFF
--- a/dashboard/ui/src/lib/evaluation-export.ts
+++ b/dashboard/ui/src/lib/evaluation-export.ts
@@ -1,0 +1,75 @@
+import type { QualityEvalReport } from "@/api/datasets";
+
+const CSV_COLUMNS = [
+  "record",
+  "timestamp",
+  "dataset",
+  "target_url",
+  "pass_threshold",
+  "task",
+  "name",
+  "input",
+  "reference",
+  "expected_tools",
+  "metric",
+  "score",
+  "pass",
+  "scorer",
+  "response",
+  "actual_tools",
+  "status_code",
+  "response_time_ms",
+  "reasoning",
+  "error",
+] as const;
+
+function csvCell(value: unknown): string {
+  const text =
+    value == null
+      ? ""
+      : Array.isArray(value) || typeof value === "object"
+        ? JSON.stringify(value)
+        : String(value);
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export function evaluationReportCsv(report: QualityEvalReport): string {
+  const rows = report.results.map((result, index) => ({
+    record: index + 1,
+    timestamp: report.timestamp,
+    dataset: report.dataset ?? "",
+    target_url: report.targetUrl,
+    pass_threshold: report.passThreshold,
+    task: result.row.task ?? "",
+    name: result.row.name ?? "",
+    input: result.row.input ?? "",
+    reference: result.row.reference ?? "",
+    expected_tools: result.row.expectedTools ?? [],
+    metric: result.metric,
+    score: result.score,
+    pass: result.pass,
+    scorer: result.scorer,
+    response: result.response,
+    actual_tools: result.actualTools ?? [],
+    status_code: result.statusCode,
+    response_time_ms: result.responseTimeMs,
+    reasoning: result.reasoning ?? "",
+    error: result.error ?? "",
+  }));
+
+  return [
+    CSV_COLUMNS.map(csvCell).join(","),
+    ...rows.map((row) =>
+      CSV_COLUMNS.map((column) => csvCell(row[column])).join(","),
+    ),
+  ].join("\r\n");
+}
+
+export function evaluationReportJson(report: QualityEvalReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function evaluationExportBaseName(filename: string): string {
+  const base = filename.replace(/\.json$/i, "").replace(/[^a-z0-9._-]+/gi, "-");
+  return base || "quality-evaluation";
+}

--- a/dashboard/ui/src/pages/DatasetsPage/index.tsx
+++ b/dashboard/ui/src/pages/DatasetsPage/index.tsx
@@ -558,7 +558,7 @@ function Segmented<T extends string>({
             onClick={() => onChange(o.value)}
             className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
               active
-                ? "bg-background text-foreground shadow-sm ring-1 ring-border"
+                ? "bg-primary text-primary-foreground shadow-sm ring-1 ring-primary"
                 : "text-muted-foreground hover:text-foreground"
             }`}
           >

--- a/dashboard/ui/src/pages/EvaluationsPage/index.tsx
+++ b/dashboard/ui/src/pages/EvaluationsPage/index.tsx
@@ -13,6 +13,11 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  evaluationExportBaseName,
+  evaluationReportCsv,
+  evaluationReportJson,
+} from "@/lib/evaluation-export";
+import {
   Swords,
   Gauge,
   Target,
@@ -35,6 +40,7 @@ import {
   Check,
   Clock,
   AlertTriangle,
+  Download,
 } from "lucide-react";
 
 type Status = "live" | "cli" | "planned";
@@ -219,6 +225,26 @@ function scoreDelta(reports: QualityReportMeta[], idx: number): number | null {
 
 function shortName(path: string): string {
   return path.split("/").slice(-2).join("/").replace(/\.json$/i, "") || path;
+}
+
+function downloadEvaluation(
+  report: QualityEvalReport,
+  filename: string,
+  format: "json" | "csv",
+) {
+  const content =
+    format === "csv" ? evaluationReportCsv(report) : evaluationReportJson(report);
+  const blob = new Blob([format === "csv" ? `\uFEFF${content}` : content], {
+    type: format === "csv" ? "text/csv;charset=utf-8" : "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${evaluationExportBaseName(filename)}.${format}`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
 }
 
 // A failing row is one of three very different problems. Separating them is
@@ -1052,6 +1078,30 @@ export function EvaluationRunPage() {
                     <span className="text-muted-foreground">total</span>
                   </span>
                 </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    downloadEvaluation(report, filename ?? "quality-evaluation.json", "csv")
+                  }
+                >
+                  <Download className="w-3.5 h-3.5" />
+                  Export CSV
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    downloadEvaluation(report, filename ?? "quality-evaluation.json", "json")
+                  }
+                >
+                  <Download className="w-3.5 h-3.5" />
+                  Export JSON
+                </Button>
               </div>
             </div>
           </div>

--- a/dashboard/ui/src/pages/NewScanPage/index.tsx
+++ b/dashboard/ui/src/pages/NewScanPage/index.tsx
@@ -238,7 +238,7 @@ function Segmented<T extends string>({
             onClick={() => onChange(o.value)}
             className={`rounded-md font-medium transition-colors ${pad} ${
               active
-                ? "bg-background text-foreground shadow-sm ring-1 ring-border"
+                ? "bg-primary text-primary-foreground shadow-sm ring-1 ring-primary"
                 : "text-muted-foreground hover:text-foreground"
             }`}
           >
@@ -1109,7 +1109,10 @@ export default function NewScanPage() {
                       <FieldRow label="Headers" hint="Auth headers sent to the MCP server (e.g. x-api-key)">
                         <div className="space-y-2">
                           {mcpHeaders.map((h, i) => (
-                            <div key={i} className="flex gap-2">
+                            <div
+                              key={i}
+                              className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2rem]"
+                            >
                               <input
                                 type="text"
                                 value={h.key}
@@ -1119,7 +1122,8 @@ export default function NewScanPage() {
                                   setMcpHeaders(copy);
                                 }}
                                 placeholder="Header name (e.g. x-api-key)"
-                                className={`${inputCls} w-1/3`}
+                                aria-label={`Header ${i + 1} name`}
+                                className={`${inputCls} min-w-0`}
                               />
                               <input
                                 type="text"
@@ -1130,13 +1134,15 @@ export default function NewScanPage() {
                                   setMcpHeaders(copy);
                                 }}
                                 placeholder="Value"
-                                className={`${inputCls} flex-1`}
+                                aria-label={`Header ${i + 1} value`}
+                                className={`${inputCls} min-w-0`}
                               />
                               {mcpHeaders.length > 1 && (
                                 <button
                                   type="button"
                                   onClick={() => setMcpHeaders(mcpHeaders.filter((_, j) => j !== i))}
-                                  className="text-muted-foreground hover:text-red-500 px-1"
+                                  aria-label={`Remove header ${i + 1}`}
+                                  className="h-10 rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive sm:w-8"
                                 >
                                   <X className="w-4 h-4" />
                                 </button>

--- a/tests/evaluation-export.test.ts
+++ b/tests/evaluation-export.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluationExportBaseName,
+  evaluationReportCsv,
+  evaluationReportJson,
+} from "../dashboard/ui/src/lib/evaluation-export.js";
+import type { QualityEvalReport } from "../dashboard/ui/src/api/datasets.js";
+
+const report: QualityEvalReport = {
+  timestamp: "2026-07-30T05:12:18.632Z",
+  targetUrl: "https://example.test/mcp",
+  dataset: "data/datasets/quality-mcp/v1-20260730-044927.json",
+  passThreshold: 0.7,
+  summary: {
+    total: 1,
+    scored: 1,
+    errors: 0,
+    score: 100,
+    passed: 1,
+    byMetric: {},
+    byTask: {},
+  },
+  results: [
+    {
+      row: {
+        task: "tool_call_accuracy",
+        name: "booking lookup",
+        input: 'Find the booking for "Jane, Doe"',
+        reference: "Use lookup_booking",
+        expectedTools: ["lookup_booking"],
+      },
+      score: 1,
+      pass: true,
+      metric: "tool_call_accuracy",
+      scorer: "deterministic",
+      response: 'Found "Jane, Doe"',
+      actualTools: ["lookup_booking"],
+      statusCode: 200,
+      responseTimeMs: 42,
+    },
+  ],
+};
+
+describe("evaluation export", () => {
+  it("exports the complete report as formatted JSON", () => {
+    expect(JSON.parse(evaluationReportJson(report))).toEqual(report);
+  });
+
+  it("exports trace rows as quoted CSV without losing commas or quotes", () => {
+    const csv = evaluationReportCsv(report);
+    expect(csv).toContain('"record","timestamp","dataset"');
+    expect(csv).toContain('"Find the booking for ""Jane, Doe"""');
+    expect(csv).toContain('"[""lookup_booking""]"');
+  });
+
+  it("creates a safe download filename", () => {
+    expect(evaluationExportBaseName("quality run 01.json")).toBe("quality-run-01");
+  });
+});


### PR DESCRIPTION
## Summary

- Makes selected segmented controls clearly distinguishable on the Launch Scan and Datasets pages.
- Fixes the MCP header editor so header names and values remain usable across supported viewport widths.
- Adds CSV and JSON downloads to saved quality-evaluation reports.
- Adds focused tests for export fidelity, CSV escaping, structured values, and safe filenames.

## Problem

Three related usability gaps affected evaluation workflows:

1. Selected segmented controls used a surface color that was too close to the surrounding background, making the active option difficult to identify.
2. MCP header fields relied on competing fixed and flexible widths in a single flex row. At constrained widths, the value field could collapse or become difficult to interact with.
3. Quality-evaluation report data was available in the browser but had no download action, preventing users from retaining or analyzing evaluation results outside the dashboard.

## Root cause

- Active-state styling depended on a subtle background and border rather than a high-contrast semantic selected state.
- The header row did not define explicit responsive columns or minimum-width behavior for both editable fields.
- The evaluation report view had no serialization and browser-download layer for its existing report model.

## Implementation

- Uses the primary color tokens for active segmented controls, including foreground and ring colors.
- Replaces the MCP header flex row with a responsive grid using two bounded input columns and a dedicated remove-control column.
- Adds explicit accessible labels for header name, value, and remove controls.
- Introduces pure evaluation export helpers:
  - formatted JSON preserves the complete report model;
  - CSV emits one row per evaluation result with report metadata, inputs, references, scores, tool traces, response details, timing, reasoning, and errors;
  - arrays and objects are JSON-encoded inside correctly escaped CSV cells;
  - filenames are normalized before download.
- Adds CSV and JSON actions to the quality-evaluation report header using browser-native Blob downloads.

## User impact

- Active options are immediately visible in light and dark themes.
- MCP authentication headers can be entered and managed reliably on desktop and narrow layouts.
- Evaluation results can be archived, shared, and analyzed without copying data from the UI.

## Compatibility and risk

- No backend endpoints, database schemas, persisted report formats, or dataset names are changed.
- Export generation is client-side and uses the existing `QualityEvalReport` type as its source of truth.
- The change is isolated to presentation and download behavior; rollback is a single commit revert.

## Validation

- `npm test -- --run tests/evaluation-export.test.ts` — 3 tests passed.
- `npm run typecheck` in `dashboard/ui` — passed.
- `npm run build` in `dashboard/ui` — passed.
- Local dashboard served successfully for manual verification.
